### PR TITLE
Reset fails flag even if ws doesn't send any data

### DIFF
--- a/custom_components/sonoff/sonoff_cloud.py
+++ b/custom_components/sonoff/sonoff_cloud.py
@@ -245,6 +245,8 @@ class EWeLinkCloud(ResponseWaiter, EWeLinkApp):
                 if time.time() - ts < 10 and fails < FAST_DELAY:
                     _LOGGER.error(CLOUD_ERROR)
                     fails = FAST_DELAY
+                else:
+                    fails = 0
 
             except ClientConnectorError as e:
                 _LOGGER.error(f"Cloud WS Connection error: {e}")


### PR DESCRIPTION
Hi, In this PR I'd like to propose a little change.

in case of the websocket https://github.com/AlexxIT/SonoffLAN/blob/e35c7ae4048d2e6257cb0bf653435c2e122845e4/custom_components/sonoff/sonoff_cloud.py#L186 doesn't send any data the fail flag is not reset and then the component will fall asleep for a while.

My idea is that the fails flag has to be reset only if some errors/exception occurs.

I've tested this PR in my scenario described here https://github.com/AlexxIT/SonoffLAN/issues/148#issuecomment-638650341 and it seems to work fine.

could you please review and check if this can be applicable?
