### PR TITLE
Minor fix for Nonetype in data variable.

### DIFF
--- a/custom_components/sonoff/sonoff_local.py
+++ b/custom_components/sonoff/sonoff_local.py
@@ -175,7 +175,7 @@ class EWeLinkLocal:
 
             data = decrypt(properties, devicekey)
             # Fix Sonoff RF Bridge sintax bug
-            if data.startswith(b'{"rf'):
+            if data and data.startswith(b'{"rf'):
                 data = data.replace(b'"="', b'":"')
         else:
             data = ''.join([properties[f'data{i}'] for i in range(1, 4, 1)


### PR DESCRIPTION
This makes the code not to throw an AttributeError: 'NoneType' object has no attribute 'startswith' if data is None.
I'm still trying to know why data is None in my execution, but I think this check is good for the code anyway.