### PR TITLE
update: yet another cause for devices not shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,7 @@ Cloud users don't have these problems.
    - Oracle VM VirtualBox
    - linux firewall
    - linux network driver
+   - incorrect network interface selected in HA Configuration -> Settings -> Global -> Network
 
 The devices publish their data through [Multicast DNS](https://en.wikipedia.org/wiki/Multicast_DNS) (mDNS/[zeroconf](https://www.home-assistant.io/integrations/zeroconf/)), read [more](http://developers.sonoff.tech/sonoff-diy-mode-api-protocol.html#Device-mDNS-Service-Info-Publish-Process).
 


### PR DESCRIPTION
I spent two days trying to figure out why SonoffLAN no longer sees my Sonoff switches after HomeAssistant upgrade. It turned out that Network integration in the new HA version had different default for NIC selection than the old one (my HA machine has two Ethernet ports).