### PR TITLE
support inching config for basic (diy) switch

### DIFF
--- a/custom_components/sonoff/__init__.py
+++ b/custom_components/sonoff/__init__.py
@@ -27,7 +27,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [
     "binary_sensor", "button", "climate", "cover", "fan", "light", "remote",
-    "sensor", "switch"
+    "sensor", "switch", "number"
 ]
 
 CONFIG_SCHEMA = vol.Schema({

--- a/custom_components/sonoff/core/devices.py
+++ b/custom_components/sonoff/core/devices.py
@@ -20,6 +20,7 @@ from ..light import *
 from ..remote import XRemote
 from ..sensor import *
 from ..switch import *
+from ..number import XPulseWidth
 
 # supported custom device_class
 DEVICE_CLASS = {
@@ -56,8 +57,10 @@ XSensor100 = spec(XSensor, multiply=0.01, round=2)
 Battery = spec(XSensor, param="battery")
 LED = spec(XToggle, param="sledOnline", uid="led", enabled=False)
 RSSI = spec(XSensor, param="rssi", enabled=False)
+PULSE = spec(XToggle, param="pulse", enabled=False)
+PULSEWIDTH = spec(XPulseWidth, param="pulseWidth", enabled=False)
 
-SPEC_SWITCH = [XSwitch, LED, RSSI]
+SPEC_SWITCH = [XSwitch, LED, RSSI, PULSE, PULSEWIDTH]
 SPEC_1CH = [Switch1, LED, RSSI]
 SPEC_2CH = [Switch1, Switch2, LED, RSSI]
 SPEC_3CH = [Switch1, Switch2, Switch3, LED, RSSI]

--- a/custom_components/sonoff/core/entity.py
+++ b/custom_components/sonoff/core/entity.py
@@ -13,6 +13,8 @@ ENTITY_CATEGORIES = {
     "battery_voltage": EntityCategory.DIAGNOSTIC,
     "led": EntityCategory.CONFIG,
     "rssi": EntityCategory.DIAGNOSTIC,
+    "pulse": EntityCategory.CONFIG,
+    "pulseWidth": EntityCategory.CONFIG,
 }
 
 ICONS = {
@@ -24,6 +26,8 @@ ICONS = {
 NAMES = {
     "led": "LED",
     "rssi": "RSSI",
+    "pulse": "INCHING",
+    "pulseWidth": "INCHING Duration",
 }
 
 

--- a/custom_components/sonoff/number.py
+++ b/custom_components/sonoff/number.py
@@ -1,0 +1,57 @@
+from homeassistant.components.number import NumberEntity
+
+from .core.const import DOMAIN
+from .core.entity import XEntity
+from .core.ewelink import XRegistry, SIGNAL_ADD_ENTITIES
+
+PARALLEL_UPDATES = 0  # fix entity_platform parallel_updates Semaphore
+
+
+async def async_setup_entry(hass, config_entry, add_entities):
+    ewelink: XRegistry = hass.data[DOMAIN][config_entry.entry_id]
+    ewelink.dispatcher_connect(
+        SIGNAL_ADD_ENTITIES,
+        lambda x: add_entities([e for e in x if isinstance(e, NumberEntity)])
+    )
+
+
+# noinspection PyAbstractClass
+class XNumber(XEntity, NumberEntity):
+    """
+    customizable number entity for simple 'params'
+    """
+    multiply: float = None
+    round: int = None
+
+    def set_state(self, params: dict):
+        value = params[self.param]
+        if self.multiply:
+            value *= self.multiply
+        if self.round is not None:
+            # convert to int when round is zero
+            value = round(value, self.round or None)
+        self._attr_value = value
+
+    async def async_set_value(self, value: float) -> None:
+        if self.multiply:
+            value /= self.multiply
+        await self.ewelink.send(self.device, {self.param: int(value)})
+
+
+class XPulseWidth(XEntity, NumberEntity):
+    
+    _attr_max_value = 36000
+    _attr_min_value = 0.5
+    _attr_step = 0.5
+
+    def set_state(self, params: dict):
+        self._attr_value = params["pulseWidth"] / 1000
+
+    async def async_set_value(self, value: float) -> None:
+        """
+        we need to send {'pulse': 'on'}  in order to also set the pilseWidth
+        else it'll reject the command
+        also, since value is in (float) seconds, ensure we send milliseconds
+        in 500 multiples (int(value / .5) * 500)
+        """
+        await self.ewelink.send(self.device, {"pulse": "on", "pulseWidth": int(value / .5) * 500})


### PR DESCRIPTION
Hello @AlexxIT ,
I've added a couple of entities to basic switches in order to be able to manage their inching feature from HA without the need to go through the ewelink app.

I was able to use the 'send_command' service for the task but then it started to get boring so I've decided to add the feature in code.

Your code is awesome and I was able to grasp the essential structure in no time (I really like it: so elegant!). Flattering apart these are the main points of this PR:
- added 2 config entities to (single?) switch devices which are disabled by default: 
  - 'pulse': this is a toggle to enable/disable inching
  - 'pulseWidth': this is a NumberEntity (new platform added to your code) to manage the inching duration
- tested only in local mode
- I guess this PR affects all the single switch entities (but I'm not sure I've correctly 'grasped' the whole picture behind initializers)
- I didn't put any check in order to see if the inching feature is available at the device level: just guessed every sonoff switch has it. If not, these entities should not harm anyway unless a user interacts with them and tries to send commands which are not supported by the device
- I've used Sonoff RE5V1C as switches in my setup: they're not DIY nor they're binded to the ewelink cloud: they just sit in my private LAN and SonoffLAN is able to work them by just setting their private key in HA configuration.yaml