### PR TITLE
Updated key name in dictionary to match device dict key name

### DIFF
--- a/custom_components/sonoff/cover.py
+++ b/custom_components/sonoff/cover.py
@@ -81,12 +81,12 @@ class XCover(XEntity, CoverEntity):
 
 # noinspection PyAbstractClass
 class XCoverDualR3(XCover):
-    params = {"currLocation", "motorTurn"}
+    params = {"location", "motorTurn"}
 
     def set_state(self, params: dict):
-        if "currLocation" in params:
+        if "location" in params:
             # 0 - closed, 100 - opened
-            self._attr_current_cover_position = params["currLocation"]
+            self._attr_current_cover_position = params["location"]
             self._attr_is_closed = self._attr_current_cover_position == 0
 
         if "motorTurn" in params:


### PR DESCRIPTION
With this change, we're now able to see the changes on the UI from using the physical switches plugged to the Dual R3.
I haven't changed the tests, as I am not completely sure if it would be impacting other places in the code.