### PR TITLE
THR316D - humidity with decimals

### DIFF
--- a/custom_components/sonoff/sensor.py
+++ b/custom_components/sonoff/sensor.py
@@ -152,8 +152,7 @@ class XHumidityTH(XSensor):
     def set_state(self, params: dict = None, value: float = None):
         try:
             value = params.get("currentHumidity") or params["humidity"]
-            # we need integer, because cloud always int, and local not
-            value = round(float(value))
+            value = float(value)
             # filter zero values
             # https://github.com/AlexxIT/SonoffLAN/issues/110
             if value != 0:


### PR DESCRIPTION
TH16R2 show in App only round numbers for humidity, but THR316D show with one decimal sign.
May be more sophisticated, like model-specific, logic can be implemented - with parameter to specify decimal signs count in output.
But for now pls not drop decimal in THR316D readings.

![image](https://user-images.githubusercontent.com/15225823/188193359-7b865065-2676-4f4e-83b9-0f99761f4149.png)