### PR TITLE
Use mDNS name instead of IP address

### DIFF
--- a/custom_components/sonoff/core/ewelink/local.py
+++ b/custom_components/sonoff/core/ewelink/local.py
@@ -117,14 +117,12 @@ class XServiceBrowser(AsyncServiceBrowser):
 
                 if not record.is_expired(now):
                     key = record.key[:18]
-                    host = None
+                    host = key + ".local."
                     port = None
                     for r, _ in records:
                         if r.key[:18] != key:
                             continue
-                        if isinstance(r, DNSAddress):
-                            host = str(ipaddress.ip_address(r.address))
-                        elif isinstance(r, DNSService):
+                        if isinstance(r, DNSService):
                             port = r.port
 
                     # support empty host and different port
@@ -154,13 +152,9 @@ class XServiceBrowser(AsyncServiceBrowser):
                             record.is_expired(now):
                         continue
 
-                    host = None
-
                     key = record.key[:18] + ".local."
+                    host = key
                     if key in cache:
-                        for r in cache[key].keys():
-                            if isinstance(r, DNSAddress):
-                                host = str(ipaddress.ip_address(r.address))
                         for r in records.keys():
                             if isinstance(r, DNSService):
                                 host += f":{r.port}"

--- a/custom_components/sonoff/core/ewelink/local.py
+++ b/custom_components/sonoff/core/ewelink/local.py
@@ -118,7 +118,7 @@ class XServiceBrowser(AsyncServiceBrowser):
                 if not record.is_expired(now):
                     key = record.key[:18]
                     host = key + ".local."
-                    port = None
+                    port = "8081"
                     for r, _ in records:
                         if r.key[:18] != key:
                             continue
@@ -154,10 +154,15 @@ class XServiceBrowser(AsyncServiceBrowser):
 
                     key = record.key[:18] + ".local."
                     host = key
+                    port = "8081"
+
                     if key in cache:
                         for r in records.keys():
                             if isinstance(r, DNSService):
-                                host += f":{r.port}"
+                                port = r.port
+
+                    if host:
+                        host += f":{port}"
 
                     data = self.decode_text(record.text)
                     asyncio.create_task(self.handler(record.name, host, data))


### PR DESCRIPTION
Bring local control for THR316D device while connection to Cloud not available.

See no changes in any other functionality - sensors, switches.
My case devices: S26, S26R2, 4CHPRO3, DualR3, DualR3 Lite, TH16, BASICRF_R3

Inspired while #939 discussions and investigation.

```
2022-09-26 13:45:59 [D] 100171fd9d UIID 0181 | {'version': 8, 'fwVersion': '1.0.2', 'switch': 'off', 'startup': 'off', 'pulseConfig': {'pulse': 'off', 'switch': 'off', 'pulseWidth': 500}, 'sledOnline': 'on', 'tempUnit': 0, 'sensorType': 'AM2301', 'currentTemperature': '9.6', 'currentHumidity': '90.2', 'rssi': -65, 'autoControl': [], 'autoControlEnabled': 0, 'uiActive': 60, 'timeZone': 3, 'only_device': {'ota': 'success', 'ota_fail_reason': 0}, 'mainSwitch': 'off', 'deviceType': 'normal'}
...
2022-09-26 13:45:59 [D] 10012b9e27 UIID 0126 | {'version': 7, 'workMode': 1, 'motorSwMode': 2, 'motorSwReverse': 0, 'outputReverse': 0, 'motorTurn': 0, 'calibState': 0, 'currLocation': 0, 'location': 0, 'sledBright': 100, 'rssi': -61, 'overload_00': {'minActPow': {'enabled': 0, 'value': 10}, 'maxVoltage': {'enabled': 0, 'value': 24000}, 'minVoltage': {'enabled': 0, 'value': 10}, 'maxCurrent': {'enabled': 1, 'value': 1500}, 'maxActPow': {'enabled': 1, 'value': 360000}}, 'overload_01': {'minActPow': {'enabled': 0, 'value': 10}, 'maxVoltage': {'enabled': 0, 'value': 24000}, 'minVoltage': {'enabled': 0, 'value': 10}, 'maxCurrent': {'enabled': 1, 'value': 1500}, 'maxActPow': {'enabled': 1, 'value': 360000}}, 'oneKwhState_00': 0, 'startTime_00': '', 'endTime_00': '', 'oneKwhState_01': 0, 'startTime_01': '', 'endTime_01': '', 'oneKwhData_00': 0, 'oneKwhData_01': 0, 'current_00': 0, 'voltage_00': 24141, 'actPow_00': 0, 'reactPow_00': 0, 'apparentPow_00': 0, 'current_01': 0, 'voltage_01': 24141, 'actPow_01': 0, 'reactPow_01': 0, 'apparentPow_01': 0, 'fwVersion': '1.4.0', 'timeZone': 3, 'swMode_00': 2, 'swMode_01': 2, 'swReverse_00': 0, 'swReverse_01': 0, 'switches': [{'switch': 'off', 'outlet': 0}, {'switch': 'off', 'outlet': 1}], 'configure': [{'startup': 'off', 'outlet': 0}, {'startup': 'off', 'outlet': 1}], 'pulses': [{'pulse': 'off', 'width': 1000, 'outlet': 0}, {'pulse': 'off', 'width': 600000, 'outlet': 1}], 'getKwh_00': 2, 'zyx_clear_timers': True, 'initSetting': 1, 'getKwh_01': 2, 'only_device': {'ota': 'success', 'ota_fail_reason': 0}, 'uiActive': {'all': 1, 'time': 7200}, 'demNextFetchTime': 1663016400000}
...
2022-09-26 13:46:11 [D] 1000e61943 => Local4 | {'switches': [{'outlet': 0, 'switch': 'on'}]} <= {'seq': 68, 'sequence': '1664189171000', 'error': 0}
2022-09-26 13:46:11 [D] 1000e61943 <= Local3 | {'sledOnline': 'on', 'configure': [{'startup': 'off', 'outlet': 0}, {'startup': 'off', 'outlet': 1}, {'startup': 'off', 'outlet': 2}, {'startup': 'off', 'outlet': 3}], 'pulses': [{'pulse': 'off', 'width': 1000, 'outlet': 0}, {'pulse': 'off', 'width': 1000, 'outlet': 1}, {'pulse': 'off', 'width': 1000, 'outlet': 2}, {'pulse': 'off', 'width': 1000, 'outlet': 3}], 'switches': [{'switch': 'on', 'outlet': 0}, {'switch': 'off', 'outlet': 1}, {'switch': 'off', 'outlet': 2}, {'switch': 'off', 'outlet': 3}]} | 68
2022-09-26 13:46:11 [D] 1000e61943 <= Cloud3 | {'switches': [{'switch': 'on', 'outlet': 0}, {'switch': 'off', 'outlet': 1}, {'switch': 'off', 'outlet': 2}, {'switch': 'off', 'outlet': 3}]} | 1664189171000
2022-09-26 13:46:12 [D] 1000e61943 => Local4 | {'switches': [{'outlet': 0, 'switch': 'off'}]} <= {'seq': 69, 'sequence': '1664189172000', 'error': 0}
2022-09-26 13:46:12 [D] 1000e61943 <= Local3 | {'sledOnline': 'on', 'configure': [{'startup': 'off', 'outlet': 0}, {'startup': 'off', 'outlet': 1}, {'startup': 'off', 'outlet': 2}, {'startup': 'off', 'outlet': 3}], 'pulses': [{'pulse': 'off', 'width': 1000, 'outlet': 0}, {'pulse': 'off', 'width': 1000, 'outlet': 1}, {'pulse': 'off', 'width': 1000, 'outlet': 2}, {'pulse': 'off', 'width': 1000, 'outlet': 3}], 'switches': [{'switch': 'off', 'outlet': 0}, {'switch': 'off', 'outlet': 1}, {'switch': 'off', 'outlet': 2}, {'switch': 'off', 'outlet': 3}]} | 69
2022-09-26 13:46:12 [D] 1000e61943 <= Cloud3 | {'switches': [{'switch': 'off', 'outlet': 0}, {'switch': 'off', 'outlet': 1}, {'switch': 'off', 'outlet': 2}, {'switch': 'off', 'outlet': 3}]} | 1664189172000

2022-09-26 14:00:51 [D] 100171fd9d => Local4 | {'switch': 'on', 'mainSwitch': 'on', 'deviceType': 'normal'} <= {'sequence': '1664190051000', 'seq': 630345, 'error': 0, 'encrypt': True}
2022-09-26 14:00:51 [D] 100171fd9d <= Local3 | {'switch': 'on', 'startup': 'off', 'pulseConfig': {'pulse': 'off', 'switch': 'off', 'pulseWidth': 500}, 'sledOnline': 'on', 'tempUnit': 0, 'timeZone': 3, 'sensorType': 'AM2301', 'currentTemperature': '17.1', 'currentHumidity': '61.6', 'autoControlEnabled': 0, 'fwVersion': '1.0.2', 'rssi': -59} | 630346
2022-09-26 14:00:51 [D] 100171fd9d <= Cloud3 | {'switch': 'on'} | 1664190051000
2022-09-26 14:00:51 [D] 100171fd9d => Local4 | {'switch': 'off', 'mainSwitch': 'off', 'deviceType': 'normal'} <= {'sequence': '1664190051001', 'seq': 630347, 'error': 0, 'encrypt': True}
2022-09-26 14:00:52 [D] 100171fd9d <= Local3 | {'switch': 'off', 'startup': 'off', 'pulseConfig': {'pulse': 'off', 'switch': 'off', 'pulseWidth': 500}, 'sledOnline': 'on', 'tempUnit': 0, 'timeZone': 3, 'sensorType': 'AM2301', 'currentTemperature': '17.1', 'currentHumidity': '61.6', 'autoControlEnabled': 0, 'fwVersion': '1.0.2', 'rssi': -60} | 630348
2022-09-26 14:00:52 [D] 100171fd9d <= Cloud3 | {'switch': 'off'} | 1664190051001
2022-09-26 14:00:54 [D] 100171fd9d <= Cloud3 | {'sensorType': 'AM2301', 'currentTemperature': '17.1', 'currentHumidity': '61.1'} | None
```

P.S. With no default port added saw in log timeout on Local4 sending command.