### PR TITLE
Support generic Zigbee lights bound via Sonoff Zigbee bridge

### DIFF
--- a/custom_components/sonoff/core/devices.py
+++ b/custom_components/sonoff/core/devices.py
@@ -206,6 +206,7 @@ DEVICES = {
     ],  # Sonoff POWR3
     1000: [XRemoteButton, Battery],  # zigbee_ON_OFF_SWITCH_1000
     1256: [spec(XSwitch, base="light")],  # ZCL_HA_DEVICEID_ON_OFF_LIGHT
+    1257: [spec(XLightD1, base="light")], # ZigbeeWhiteLight
     # https://github.com/AlexxIT/SonoffLAN/issues/972
     1514: [XZigbeeCover, spec(XSensor, param="battery", multiply=2)],
     1770: [


### PR DESCRIPTION
This allows to control generic Zigbee lights connected via Sonoff Zigbee bridge. In my case tested with IKEA 404.867.83, which is dimmable.

I don't know if any light will use UUID 1257, so overall might be not acceptable merge as would work inconsistently depending on the device.

And it might make sense to rename `XLightD1` to something more generic if it handles multiple devices.