### PR TITLE
Fix/allow LAN mode for THR316/20D, DualR3 & DualR3 Lite

### DIFF
--- a/custom_components/sonoff/core/ewelink/__init__.py
+++ b/custom_components/sonoff/core/ewelink/__init__.py
@@ -236,11 +236,14 @@ class XRegistry(XRegistryBase):
         if "sledOnline" in params:
             device["params"]["sledOnline"] = params["sledOnline"]
 
-        # we can get data from device, but without host
-        if "host" in msg and device.get("host") != msg["host"]:
-            # params for custom sensor
-            device["host"] = params["host"] = msg["host"]
+        if "localtype" in msg and device.get("localtype") != msg.get("localtype"):
             device["localtype"] = msg["localtype"]
+
+        if not "host" in msg:
+            msg["host"] = f"ewelink_{did}.local:8081"
+
+        if device.get("host") != msg.get("host"):
+            device["host"] = params["host"] = msg["host"]
 
         self.dispatcher_send(did, params)
 


### PR DESCRIPTION
When receiving Local0 - fill up 'host' with "ewelink_{did}.local:8081" and update device 'localtype' to same as in message received. Also update 'host' & 'localtype' in case message contains different to device.

Mentioned devices control checked & recorder with and without Internet connection available. 
As well devices removal connection to network too.

Result: #1066 fixed, devices still available during Internet outage, data from THR3 recorded in HA, switched locally controled.