### PR TITLE
3.4.0. False local offline's fix

### DIFF
--- a/custom_components/sonoff/core/entity.py
+++ b/custom_components/sonoff/core/entity.py
@@ -95,7 +95,7 @@ class XEntity(Entity):
 
     def internal_available(self) -> bool:
         return (self.ewelink.cloud.online and self.device.get("online")) or (
-            self.ewelink.local.online and "host" in self.device
+            self.ewelink.local.online and self.device.get("local")
         )
 
     def internal_update(self, params: dict = None):

--- a/custom_components/sonoff/core/ewelink/__init__.py
+++ b/custom_components/sonoff/core/ewelink/__init__.py
@@ -238,7 +238,7 @@ class XRegistry(XRegistryBase):
 
         tag = "Local3" if "host" in msg else "Local0"
 
-        _LOGGER.debug(f"{did} <= {tag} | %s | {msg.get('seq', '')}", params)
+        _LOGGER.debug(f"{did} <= {tag} | {msg.get('host','')} | %s | {msg.get('seq', '')}", params)
 
         # msg from zeroconf ServiceStateChange.Removed
         if params.get("online") is False:

--- a/custom_components/sonoff/core/ewelink/__init__.py
+++ b/custom_components/sonoff/core/ewelink/__init__.py
@@ -116,6 +116,9 @@ class XRegistry(XRegistryBase):
             ok = await self.cloud.send(device, params, seq)
             if ok == "online" and query_cloud and params:
                 await self.cloud.send(device, timeout=0)
+            # check LAN status if local mode configured
+            if self.local.online: 
+                asyncio.create_task(self.check_offline(device))
 
         else:
             return
@@ -182,9 +185,8 @@ class XRegistry(XRegistryBase):
         # process online change
         if "online" in params:
             device["online"] = params["online"]
-            # check if LAN online after cloud offline
-            if not device["online"] and device.get("host"):
-                asyncio.create_task(self.check_offline(device))
+            # check if LAN online after cloud status change
+            asyncio.create_task(self.check_offline(device))
 
         elif device["online"] is False:
             device["online"] = True

--- a/custom_components/sonoff/core/ewelink/__init__.py
+++ b/custom_components/sonoff/core/ewelink/__init__.py
@@ -151,8 +151,6 @@ class XRegistry(XRegistryBase):
             device["local_ts"] = time.time() + LOCAL_TTL
             return
 
-        device.pop("host", None)
-
         did = device["deviceid"]
         _LOGGER.debug(f"{did} !! Local4 | Device offline")
         self.dispatcher_send(did)
@@ -284,7 +282,6 @@ class XRegistry(XRegistryBase):
                 for device in self.devices.values():
                     if "local_ts" not in device or device["local_ts"] > ts:
                         continue
-                    device.pop("local_ts")
                     asyncio.create_task(self.check_offline(device))
 
             await asyncio.sleep(15)

--- a/custom_components/sonoff/core/ewelink/__init__.py
+++ b/custom_components/sonoff/core/ewelink/__init__.py
@@ -91,7 +91,7 @@ class XRegistry(XRegistryBase):
         """
         seq = self.sequence()
 
-        can_local = self.local.online and device.get("host")
+        can_local = self.local.online and device.get("local")
         can_cloud = self.cloud.online and device.get("online")
 
         if can_local and can_cloud:
@@ -149,8 +149,10 @@ class XRegistry(XRegistryBase):
         ok = await self.local.send(device, {"cmd": "info"}, timeout=10)
         if ok == "online":
             device["local_ts"] = time.time() + LOCAL_TTL
+            device["local"] = True
             return
 
+        device["local"] = False
         did = device["deviceid"]
         _LOGGER.debug(f"{did} !! Local4 | Device offline")
         self.dispatcher_send(did)
@@ -253,6 +255,7 @@ class XRegistry(XRegistryBase):
             device["localtype"] = msg["localtype"]
 
         device["local_ts"] = time.time() + LOCAL_TTL
+        device["local"] = True
 
         self.dispatcher_send(did, params)
 

--- a/custom_components/sonoff/core/ewelink/base.py
+++ b/custom_components/sonoff/core/ewelink/base.py
@@ -20,6 +20,7 @@ class XDevice(TypedDict, total=False):
     online: Optional[bool]  # required for cloud
     apikey: Optional[str]  # required for cloud
 
+    local: Optional[str]  # required for local
     localtype: Optional[str]  # exist for local DIY device type
     host: Optional[str]  # required for local
     devicekey: Optional[str]  # required for encrypted local devices (not DIY)

--- a/custom_components/sonoff/core/ewelink/local.py
+++ b/custom_components/sonoff/core/ewelink/local.py
@@ -111,17 +111,11 @@ class XRegistryLocal(XRegistryBase):
 
             # support update with empty host and host without port
             host = None
-            if info.server:
-                host = info.server
-            else:			
-                for addr in info.addresses:
-                    # zeroconf lib should return IPv4, but better check anyway
-                    host = str(ipaddress.IPv4Address(addr))
-                    break
-
-            if host:
-                port = str(info.port) if info.port else "8081"
-                host += ":" + port
+            for addr in info.addresses:
+                # zeroconf lib should return IPv4, but better check anyway
+                addr = ipaddress.IPv4Address(addr)
+                host = f"{addr}:{info.port}" if info.port else str(addr)
+                break
 
             data = {
                 k.decode(): v.decode() if isinstance(v, bytes) else v

--- a/custom_components/sonoff/core/ewelink/local.py
+++ b/custom_components/sonoff/core/ewelink/local.py
@@ -188,7 +188,7 @@ class XRegistryLocal(XRegistryBase):
         if "devicekey" in device:
             payload = encrypt(payload, device["devicekey"])
 
-        log = f"{device['deviceid']} => Local4 | {params}"
+        log = f"{device['deviceid']} => Local4 | {device.get('host','')} | {params}"
 
         try:
             host = device["host"]

--- a/custom_components/sonoff/core/ewelink/local.py
+++ b/custom_components/sonoff/core/ewelink/local.py
@@ -111,11 +111,17 @@ class XRegistryLocal(XRegistryBase):
 
             # support update with empty host and host without port
             host = None
-            for addr in info.addresses:
-                # zeroconf lib should return IPv4, but better check anyway
-                addr = ipaddress.IPv4Address(addr)
-                host = f"{addr}:{info.port}" if info.port else str(addr)
-                break
+            if info.server:
+                host = info.server
+            else:			
+                for addr in info.addresses:
+                    # zeroconf lib should return IPv4, but better check anyway
+                    host = str(ipaddress.IPv4Address(addr))
+                    break
+
+            if host:
+                port = str(info.port) if info.port else "8081"
+                host += ":" + port
 
             data = {
                 k.decode(): v.decode() if isinstance(v, bytes) else v

--- a/custom_components/sonoff/core/ewelink/local.py
+++ b/custom_components/sonoff/core/ewelink/local.py
@@ -97,8 +97,6 @@ class XRegistryLocal(XRegistryBase):
     ):
         """Step 1. Receive change event from zeroconf."""
         if state_change == ServiceStateChange.Removed:
-            msg = {"deviceid": name[8:18], "params": {"online": False}}
-            self.dispatcher_send(SIGNAL_UPDATE, msg)
             return
 
         asyncio.create_task(self._handler2(zeroconf, service_type, name))

--- a/custom_components/sonoff/core/ewelink/local.py
+++ b/custom_components/sonoff/core/ewelink/local.py
@@ -117,6 +117,9 @@ class XRegistryLocal(XRegistryBase):
                 host = f"{addr}:{info.port}" if info.port else str(addr)
                 break
 
+            if not host and info.server:
+                host = info.server
+
             data = {
                 k.decode(): v.decode() if isinstance(v, bytes) else v
                 for k, v in info.properties.items()

--- a/custom_components/sonoff/diagnostics.py
+++ b/custom_components/sonoff/diagnostics.py
@@ -36,6 +36,7 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
                 },
                 "model": device.get("productModel"),
                 "online": device.get("online"),
+                "local": device.get("local"),
                 "localtype": device.get("localtype"),
                 "host": device.get("host"),
             }


### PR DESCRIPTION
1. Ignoring ServiceStateChange.Removed events - have no correlation with device availability, but with data transfer initiated from device;
2. Do not clear 'host' : will keep last known Good IP to use it in ```check_offline```, to be possible recover offline device;
3. Do not clear 'last_ts': let keep last activity timestamp, other way it blocks further ```check_offline``` calls;
4. If suddenly ```AsyncServiceInfo``` return no IPv4 addresses - use 'info.server' as 'host';
5. 'local' property return back to keep track local online/offline status;
6. More ```check_offline``` calls - on every Cloud status change & device currently offline but local mode enabled;
7. Add 'host' value to Local3 & Local4 debug logs.