### PR TITLE
Added the SNZB-01P device definition

### DIFF
--- a/custom_components/sonoff/core/devices.py
+++ b/custom_components/sonoff/core/devices.py
@@ -367,6 +367,10 @@ DEVICES = {
         spec(XZigbeeSwitches, channel=2, uid="3"),
         spec(XZigbeeSwitches, channel=3, uid="4"),
     ],
+    7000: [
+        XRemoteButton,
+        Battery,
+    ],
     7014: [
         spec(XSensor100, param="temperature"),
         spec(XSensor100, param="humidity"),


### PR DESCRIPTION
I just purchased a bunch of Sonoff SNZB-01P (https://sonoff.tech/product/gateway-and-sensors/snzb-01p/)

I noticed that it was not showing up and behaving properly. After some digging, I found out that this particular device did not have a definition. I went ahead and added it. 

<details><summary>For reference, here's the json of this device in my installation:</summary>

```
{
  "home_assistant": {
    "installation_type": "Home Assistant Container",
    "version": "2023.6.2",
    "dev": false,
    "hassio": false,
    "virtualenv": false,
    "python_version": "3.11.4",
    "docker": true,
    "arch": "x86_64",
    "timezone": "America/New_York",
    "os_name": "Linux",
    "os_version": "5.19.17-Unraid",
    "run_as_root": true
  },
  "custom_components": {
    "xiaomi_cloud_map_extractor": {
      "version": "v2.2.0",
      "requirements": [
        "pillow",
        "pybase64",
        "python-miio",
        "requests",
        "pycryptodome"
      ]
    },
    "waste_management": {
      "version": "0.1.6",
      "requirements": [
        "waste-management==3.1.1"
      ]
    },
    "upnp_availability": {
      "version": "0.0.3",
      "requirements": [
        "async_upnp_client>=0.33"
      ]
    },
    "sinope": {
      "version": "1.5.8",
      "requirements": [
        "crc8==0.1.0"
      ]
    },
    "neviweb": {
      "version": "2.1.4",
      "requirements": []
    },
    "localtuya": {
      "version": "5.2.1",
      "requirements": []
    },
    "google_home": {
      "version": "1.10.0",
      "requirements": [
        "glocaltokens==0.7.0"
      ]
    },
    "ui_lovelace_minimalist": {
      "version": "v1.3.6",
      "requirements": [
        "aiofiles==0.8.0",
        "aiogithubapi>=22.2.4"
      ]
    },
    "thermal_comfort": {
      "version": "2.1.1",
      "requirements": []
    },
    "google_photos": {
      "version": "v0.6.0",
      "requirements": [
        "google-api-python-client>=2.71.0",
        "pillow>=9.1.1,<10.0.0"
      ]
    },
    "sonoff": {
      "version": "3.5.1",
      "requirements": [
        "pycryptodome>=3.6.6"
      ]
    },
    "husqvarna_automower": {
      "version": "2023.6.0",
      "requirements": [
        "aioautomower==2023.4.4",
        "geopy>=2.1.0",
        "numpy>=1.21.6",
        "Pillow>=9.1.1"
      ]
    },
    "lightener": {
      "version": "v2.2.0",
      "requirements": []
    },
    "hacs": {
      "version": "1.32.1",
      "requirements": [
        "aiogithubapi>=22.10.1"
      ]
    },
    "adaptive_lighting": {
      "version": "1.14.0",
      "requirements": [
        "ulid-transform"
      ]
    }
  },
  "integration_manifest": {
    "domain": "sonoff",
    "name": "Sonoff",
    "config_flow": true,
    "documentation": "https://github.com/AlexxIT/SonoffLAN",
    "issue_tracker": "/api/sonoff/eab07988-9d94-46fc-9bc0-b8ae322a3836",
    "codeowners": [
      "@AlexxIT"
    ],
    "dependencies": [
      "http",
      "zeroconf"
    ],
    "requirements": [
      "pycryptodome>=3.6.6"
    ],
    "version": "3.5.1",
    "iot_class": "local_push",
    "is_built_in": false
  },
  "data": {
    "version": "eb3224c",
    "cloud_auth": true,
    "config": null,
    "options": {
      "mode": "auto",
      "debug": true
    },
    "errors": [],
    "device": {
      "uiid": 7000,
      "params": {
        "bindInfos": "***",
        "subDevId": "4442d2feff20ba847000",
        "parentid": "1001dc7ed3",
        "fwVersion": "2.0.0",
        "battery": 100,
        "trigTime": "1687319897000",
        "supportPowConfig": 1,
        "key": 0
      },
      "model": "SNZB-01P",
      "online": true,
      "local": null,
      "localtype": null,
      "host": null,
      "deviceid": "a44001c2fe"
    }
  }
}

```

</details> 