### PR TITLE
[README] Added description to override uiid

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,16 @@ sonoff:
     1000xxxxxx:
       device_class: shutter
 ```
+You can set the `uiid` when running in DIY mode to enable the device features.
+You can view the list of `uiid`'s and the associated device in `device.py:131`
+
+```yaml
+sonoff:
+  devices:
+    1000xxxxxx:
+      extra:
+        uiid: 136 # Sonoff B05-BL
+```
 
 ### Custom devices
 


### PR DESCRIPTION
When devices run in DIY mode there is no way to detect the device type and feature set.
Currently devices will report it as a `DIY` type.

After investigating the code base, I've discovered that you can set the `uiid` using the configuration (not explicitly mentioned in the docs) using the config loader for the device https://github.com/AlexxIT/SonoffLAN/blob/8c8ba2e29573331fe14808f6c74f0708fce7ade3/custom_components/sonoff/core/ewelink/__init__.py#L42