### PR TITLE
Improve Local Mode

### DIFF
--- a/custom_components/sonoff/core/ewelink/__init__.py
+++ b/custom_components/sonoff/core/ewelink/__init__.py
@@ -98,7 +98,7 @@ class XRegistry(XRegistryBase):
           ignored if params empty
         :param timeout_lan: optional custom LAN timeout
         """
-        seq = self.sequence()
+        seq = await self.sequence()
 
         if "parent" in device:
             main_device = device["parent"]

--- a/custom_components/sonoff/core/ewelink/base.py
+++ b/custom_components/sonoff/core/ewelink/base.py
@@ -43,7 +43,7 @@ class XRegistryBase:
     @staticmethod
     def sequence() -> str:
         """Return sequnce counter in ms. Always unique."""
-        t = int(time.time()) * 1000
+        t = time.time_ns() // 1_000_000
         if t > XRegistryBase._sequence:
             XRegistryBase._sequence = t
         else:

--- a/custom_components/sonoff/core/ewelink/base.py
+++ b/custom_components/sonoff/core/ewelink/base.py
@@ -35,20 +35,22 @@ class XDevice(TypedDict, total=False):
 class XRegistryBase:
     dispatcher: dict[str, list[Callable]] = None
     _sequence: int = 0
+    _sequence_lock: asyncio.Lock = asyncio.Lock()
 
     def __init__(self, session: ClientSession):
         self.dispatcher = {}
         self.session = session
 
     @staticmethod
-    def sequence() -> str:
+    async def sequence() -> str:
         """Return sequnce counter in ms. Always unique."""
         t = time.time_ns() // 1_000_000
-        if t > XRegistryBase._sequence:
-            XRegistryBase._sequence = t
-        else:
-            XRegistryBase._sequence += 1
-        return str(XRegistryBase._sequence)
+        async with XRegistryBase._sequence_lock:
+            if t > XRegistryBase._sequence:
+                XRegistryBase._sequence = t
+            else:
+                XRegistryBase._sequence += 1
+            return str(XRegistryBase._sequence)
 
     def dispatcher_connect(self, signal: str, target: Callable) -> Callable:
         targets = self.dispatcher.setdefault(signal, [])

--- a/custom_components/sonoff/core/ewelink/cloud.py
+++ b/custom_components/sonoff/core/ewelink/cloud.py
@@ -220,7 +220,7 @@ class XRegistryCloud(ResponseWaiter, XRegistryBase):
         self.last_ts = time.time()
 
         if sequence is None:
-            sequence = self.sequence()
+            sequence = await self.sequence()
         log += sequence
 
         # https://coolkit-technologies.github.io/eWeLink-API/#/en/APICenterV2?id=websocket-update-device-status

--- a/custom_components/sonoff/core/ewelink/local.py
+++ b/custom_components/sonoff/core/ewelink/local.py
@@ -174,7 +174,7 @@ class XRegistryLocal(XRegistryBase):
             command = next(iter(params))
 
         payload = {
-            "sequence": sequence or self.sequence(),
+            "sequence": sequence or await self.sequence(),
             "deviceid": device["deviceid"],
             "selfApikey": "123",
             "data": params or {},

--- a/custom_components/sonoff/core/ewelink/local.py
+++ b/custom_components/sonoff/core/ewelink/local.py
@@ -5,6 +5,7 @@ devices and their devicekey.
 """
 import asyncio
 import base64
+import errno
 import ipaddress
 import json
 import logging
@@ -162,6 +163,7 @@ class XRegistryLocal(XRegistryBase):
         command: str = None,
         sequence: str = None,
         timeout: int = 5,
+        cre_retry_counter: int = 10,
     ):
         # known commands for DIY: switch, startup, pulse, sledonline
         # other commands: switch, switches, transmit, dimmable, light, fan
@@ -231,8 +233,31 @@ class XRegistryLocal(XRegistryBase):
             _LOGGER.debug(f"{log} !! Can't connect: {e}")
             return "E#CON"
 
+        except aiohttp.ClientOSError as e:
+            if e.errno != errno.ECONNRESET:
+                _LOGGER.debug(log, exc_info=e)
+                return "E#COE"  # ClientOSError
+
+            # This happens because the device's web server is not multi-threaded
+            # and can only process one request at a time. Therefore, if the
+            # device is busy processing another request, it will close the
+            # connection for the new request and we will get this error.
+            #
+            # It appears that the device takes some time to process a new request
+            # after the previous one was closed, which caused a locking approach
+            # to not work across different devices. Simply retrying on this error
+            # a few times seems to fortunately work reliably, so we'll do that.
+
+            _LOGGER.debug(f"{log} !! ConnectionResetError")
+            if cre_retry_counter > 0:
+                await asyncio.sleep(0.1)
+                return await self.send(
+                    device, params, command, sequence, timeout, cre_retry_counter - 1
+                )
+
+            return "E#CRE"  # ConnectionResetError
+
         except (
-            aiohttp.ClientOSError,
             aiohttp.ServerDisconnectedError,
             asyncio.CancelledError,
         ) as e:


### PR DESCRIPTION
-   Improve Local Mode Reliability

    Local mode devices cannot handle more than 1 concurrent connection
    to the HTTP server. This means that if an additional connection is
    made when another one is pending or is in the process of being
    cleaned up by the device, it will return connection reset error.
    
    ## Mention of Failed Attempt
    
    An approach where we acquire a lock and wait 100ms whenever we
    use the send() method was attempted but did not work consistently
    on all devices. My theory is that depending the on the processing
    on the device, it takes a different amount of time for it to
    reallocate resources to the next new connection.
    
    Therefore, simply retrying has worked just fine in my testing.
    It also has the added advantage of working despite another HA
    instance, app, etc. taking advantage of local mode.
    
-   Use time.time_ns() to generate sequence number
    
    Converting time.time() to an int and then converting that to ms
    risks resulting in the same sequence number for a given second.
    While we have safe guards against this already, it is better
    to prevent this scenario all together and just convert to ms
    properly.
    
- Acquire lock when performing comparisons against/returning of sequence
    
    Prevent the same sequence number being returned for different threads
    as this might cause hard to detect issues.
