### PR TITLE
Set force_update for sensors to fix issues when value does not change

### DIFF
--- a/custom_components/sonoff/core/entity.py
+++ b/custom_components/sonoff/core/entity.py
@@ -1,5 +1,6 @@
 import logging
 
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo, Entity, EntityCategory
 
@@ -93,6 +94,11 @@ class XEntity(Entity):
 
         if parent := device.get("parent"):
             ewelink.dispatcher_connect(parent["deviceid"], self.internal_parent_update)
+
+    @property
+    def force_update(self) -> bool:
+        """Force update."""
+        return isinstance(self, SensorEntity)
 
     def set_state(self, params: dict):
         pass


### PR DESCRIPTION
For example,

- Riemann Sum integral integration does not register change if power value was the same. It needs some attribute change. This also breaks that sensor if it went from "unavailable" to a known constant value.

- Graphs don't make as much sense.