### PR TITLE
Replace deprecated constants to fix warnings in HA 2024.1

### DIFF
--- a/custom_components/sonoff/climate.py
+++ b/custom_components/sonoff/climate.py
@@ -1,16 +1,9 @@
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
-    HVAC_MODE_AUTO,
-    HVAC_MODE_COOL,
-    HVAC_MODE_DRY,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_HEAT_COOL,
-    HVAC_MODE_OFF,
-    SUPPORT_PRESET_MODE,
-    SUPPORT_TARGET_TEMPERATURE,
-    SUPPORT_TARGET_TEMPERATURE_RANGE,
+    ClimateEntityFeature,
+    HVACMode,
 )
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import UnitOfTemperature
 
 from .core.const import DOMAIN
 from .core.entity import XEntity
@@ -33,13 +26,13 @@ class XClimateTH(XEntity, ClimateEntity):
 
     _attr_entity_registry_enabled_default = False
     _attr_hvac_mode = None
-    _attr_hvac_modes = [HVAC_MODE_OFF, HVAC_MODE_HEAT, HVAC_MODE_COOL, HVAC_MODE_DRY]
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL, HVACMode.DRY]
     _attr_max_temp = 99
     _attr_min_temp = 1
-    _attr_supported_features = SUPPORT_TARGET_TEMPERATURE_RANGE
+    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
     _attr_target_temperature_high = None
     _attr_target_temperature_low = None
-    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 1
 
     heat: bool = None
@@ -53,16 +46,16 @@ class XClimateTH(XEntity, ClimateEntity):
             self._attr_target_temperature_low = float(lo["targetLow"])
 
             if params["deviceType"] == "normal":
-                self._attr_hvac_mode = HVAC_MODE_OFF
+                self._attr_hvac_mode = HVACMode.OFF
             elif params["deviceType"] == "humidity":
-                self._attr_hvac_mode = HVAC_MODE_DRY
+                self._attr_hvac_mode = HVACMode.DRY
             elif self.is_aux_heat:
-                self._attr_hvac_mode = HVAC_MODE_HEAT
+                self._attr_hvac_mode = HVACMode.HEAT
             else:
-                self._attr_hvac_mode = HVAC_MODE_COOL
+                self._attr_hvac_mode = HVACMode.COOL
 
         try:
-            if self.hvac_mode != HVAC_MODE_DRY:
+            if self.hvac_mode != HVACMode.DRY:
                 value = float(params.get("currentTemperature") or params["temperature"])
                 value = round(value, 1)
             else:
@@ -84,19 +77,19 @@ class XClimateTH(XEntity, ClimateEntity):
         ]
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
-        if hvac_mode == HVAC_MODE_HEAT:
+        if hvac_mode == HVACMode.HEAT:
             params = {
                 "mainSwitch": "on",
                 "deviceType": "temperature",
                 "targets": self.get_targets(True),
             }
-        elif hvac_mode == HVAC_MODE_COOL:
+        elif hvac_mode == HVACMode.COOL:
             params = {
                 "mainSwitch": "on",
                 "deviceType": "temperature",
                 "targets": self.get_targets(False),
             }
-        elif hvac_mode == HVAC_MODE_DRY:
+        elif hvac_mode == HVACMode.DRY:
             params = {
                 "mainSwitch": "on",
                 "deviceType": "humidity",
@@ -116,13 +109,13 @@ class XClimateTH(XEntity, ClimateEntity):
         heat = self.is_aux_heat
         if hvac_mode is None:
             params = {}
-        elif hvac_mode == HVAC_MODE_HEAT:
+        elif hvac_mode == HVACMode.HEAT:
             heat = True
             params = {"mainSwitch": "on", "deviceType": "temperature"}
-        elif hvac_mode == HVAC_MODE_COOL:
+        elif hvac_mode == HVACMode.COOL:
             heat = False
             params = {"mainSwitch": "on", "deviceType": "temperature"}
-        elif hvac_mode == HVAC_MODE_DRY:
+        elif hvac_mode == HVACMode.DRY:
             params = {"mainSwitch": "on", "deviceType": "humidity"}
         else:
             params = {"mainSwitch": "off", "deviceType": "normal"}
@@ -147,11 +140,11 @@ class XClimateNS(XEntity, ClimateEntity):
     params = {"ATCEnable", "ATCMode", "temperature", "tempCorrection"}
 
     _attr_entity_registry_enabled_default = False
-    _attr_hvac_modes = [HVAC_MODE_OFF, HVAC_MODE_HEAT_COOL, HVAC_MODE_AUTO]
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT_COOL, HVACMode.AUTO]
     _attr_max_temp = 31
     _attr_min_temp = 16
-    _attr_supported_features = SUPPORT_TARGET_TEMPERATURE
-    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 1
 
     def set_state(self, params: dict):
@@ -161,18 +154,18 @@ class XClimateNS(XEntity, ClimateEntity):
 
         if "HMI_ATCDevice" in params and "etype" in params["HMI_ATCDevice"]:
             if cache["HMI_ATCDevice"]["etype"] == "cold":
-                self._attr_hvac_modes[1] = HVAC_MODE_COOL
+                self._attr_hvac_modes[1] = HVACMode.COOL
             else:
-                self._attr_hvac_modes[1] = HVAC_MODE_HEAT
+                self._attr_hvac_modes[1] = HVACMode.HEAT
 
         if "ATCEnable" in params or "ATCMode" in params:
             if cache["ATCEnable"]:
                 if cache["ATCMode"]:
-                    self.set_hvac_attr(HVAC_MODE_AUTO)
+                    self.set_hvac_attr(HVACMode.AUTO)
                 else:
                     self.set_hvac_attr(self._attr_hvac_modes[1])
             else:
-                self.set_hvac_attr(HVAC_MODE_OFF)
+                self.set_hvac_attr(HVACMode.OFF)
 
         if "ATCExpect0" in params:
             self._attr_target_temperature = cache["ATCExpect0"]
@@ -188,25 +181,25 @@ class XClimateNS(XEntity, ClimateEntity):
                 pass
 
     def set_hvac_attr(self, hvac_mode: str) -> None:
-        if hvac_mode == HVAC_MODE_AUTO:
+        if hvac_mode == HVACMode.AUTO:
             self._attr_hvac_mode = hvac_mode
             self._attr_supported_features = 0
-        elif hvac_mode == HVAC_MODE_OFF:
+        elif hvac_mode == HVACMode.OFF:
             self._attr_hvac_mode = hvac_mode
-            self._attr_supported_features = SUPPORT_TARGET_TEMPERATURE
-        elif hvac_mode in (HVAC_MODE_COOL, HVAC_MODE_HEAT, HVAC_MODE_HEAT_COOL):
+            self._attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+        elif hvac_mode in (HVACMode.COOL, HVACMode.HEAT, HVACMode.HEAT_COOL):
             self._attr_hvac_mode = self._attr_hvac_modes[1]
-            self._attr_supported_features = SUPPORT_TARGET_TEMPERATURE
+            self._attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
 
     @staticmethod
     def get_params(hvac_mode: str) -> dict:
-        if hvac_mode == HVAC_MODE_AUTO:
+        if hvac_mode == HVACMode.AUTO:
             return {"ATCEnable": 1, "ATCMode": 1}
-        elif hvac_mode in (HVAC_MODE_COOL, HVAC_MODE_HEAT):
+        elif hvac_mode in (HVACMode.COOL, HVACMode.HEAT):
             return {"ATCEnable": 1, "ATCMode": 0}
-        elif hvac_mode == HVAC_MODE_HEAT_COOL:
+        elif hvac_mode == HVACMode.HEAT_COOL:
             return {"ATCEnable": 1}  # async_turn_on
-        elif hvac_mode == HVAC_MODE_OFF:
+        elif hvac_mode == HVACMode.OFF:
             return {"ATCEnable": 0}
         else:
             return {}
@@ -233,12 +226,12 @@ class XThermostat(XEntity, ClimateEntity):
     params = {"switch", "targetTemp", "temperature", "workMode", "workState"}
 
     # @bwp91 https://github.com/AlexxIT/SonoffLAN/issues/358
-    _attr_hvac_modes = [HVAC_MODE_OFF, HVAC_MODE_HEAT, HVAC_MODE_AUTO]
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.AUTO]
     _attr_max_temp = 45
     _attr_min_temp = 5
     _attr_preset_modes = ["manual", "programmed", "economical"]
-    _attr_supported_features = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
-    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 0.5
 
     def set_state(self, params: dict):
@@ -250,7 +243,7 @@ class XThermostat(XEntity, ClimateEntity):
             # workState: 1=heating, 2=auto
             self._attr_hvac_mode = self.hvac_modes[cache["workState"]]
         else:
-            self._attr_hvac_mode = HVAC_MODE_OFF
+            self._attr_hvac_mode = HVACMode.OFF
 
         if "workMode" in params:
             self._attr_preset_mode = self.preset_modes[params["workMode"] - 1]
@@ -278,7 +271,7 @@ class XThermostat(XEntity, ClimateEntity):
     ) -> None:
         if hvac_mode is None:
             params = {}
-        elif hvac_mode is HVAC_MODE_OFF:
+        elif hvac_mode is HVACMode.OFF:
             params = {"switch": "off"}
         else:
             i = self.hvac_modes.index(hvac_mode)

--- a/custom_components/sonoff/core/backward.py
+++ b/custom_components/sonoff/core/backward.py
@@ -1,4 +1,4 @@
-"""Why Hass v2021.12 minimal?
+"""Why Hass v2022.5 minimal?
 
 - v2021.7 - new Entity attributes style
 - v2021.8 - new electric unit_of_measurement
@@ -7,7 +7,8 @@
 - v2021.12 - new ButtonEntity
 - v2021.12 - new FanEntity percentage logic
 - v2021.12 - new SensorDeviceClass, SensorStateClass classes
+- v2022.5 - new LightEntity ColorMode and LightEntityFeature
 """
 from homeassistant.const import MAJOR_VERSION, MINOR_VERSION
 
-hass_version_supported = (MAJOR_VERSION, MINOR_VERSION) >= (2021, 12)
+hass_version_supported = (MAJOR_VERSION, MINOR_VERSION) >= (2022, 5)

--- a/custom_components/sonoff/core/backward.py
+++ b/custom_components/sonoff/core/backward.py
@@ -1,4 +1,4 @@
-"""Why Hass v2022.5 minimal?
+"""Why Hass v2023.1 minimal?
 
 - v2021.7 - new Entity attributes style
 - v2021.8 - new electric unit_of_measurement
@@ -8,7 +8,9 @@
 - v2021.12 - new FanEntity percentage logic
 - v2021.12 - new SensorDeviceClass, SensorStateClass classes
 - v2022.5 - new LightEntity ColorMode and LightEntityFeature
+- v2022.11 - new UnitOfEnergy, UnitOfPower, UnitOfTemperature
+- V2023.1 - new UnitOfElectricCurrent, UnitOfElectricPotential
 """
 from homeassistant.const import MAJOR_VERSION, MINOR_VERSION
 
-hass_version_supported = (MAJOR_VERSION, MINOR_VERSION) >= (2022, 5)
+hass_version_supported = (MAJOR_VERSION, MINOR_VERSION) >= (2023, 1)

--- a/custom_components/sonoff/fan.py
+++ b/custom_components/sonoff/fan.py
@@ -1,7 +1,6 @@
 from homeassistant.components.fan import (
-    SUPPORT_PRESET_MODE,
-    SUPPORT_SET_SPEED,
     FanEntity,
+    FanEntityFeature,
 )
 
 from .core.const import DOMAIN
@@ -29,7 +28,7 @@ SPEED_HIGH = "high"
 class XFan(XEntity, FanEntity):
     params = {"switches", "fan"}
     _attr_speed_count = 3
-    _attr_supported_features = SUPPORT_SET_SPEED | SUPPORT_PRESET_MODE
+    _attr_supported_features = FanEntityFeature.SET_SPEED | FanEntityFeature.PRESET_MODE
     _attr_preset_modes = [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
     def set_state(self, params: dict):

--- a/custom_components/sonoff/light.py
+++ b/custom_components/sonoff/light.py
@@ -1,13 +1,9 @@
 import time
 
 from homeassistant.components.light import (
-    COLOR_MODE_BRIGHTNESS,
-    COLOR_MODE_COLOR_TEMP,
-    COLOR_MODE_ONOFF,
-    COLOR_MODE_RGB,
-    SUPPORT_EFFECT,
-    SUPPORT_TRANSITION,
+    ColorMode,
     LightEntity,
+    LightEntityFeature,
 )
 from homeassistant.util import color
 
@@ -46,9 +42,9 @@ class XLight(XEntity, LightEntity):
     uid = ""  # prevent add param to entity_id
 
     # support on/off and brightness
-    _attr_color_mode = COLOR_MODE_BRIGHTNESS
-    _attr_supported_color_modes = {COLOR_MODE_BRIGHTNESS}
-    _attr_supported_features = SUPPORT_TRANSITION
+    _attr_color_mode = ColorMode.BRIGHTNESS
+    _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+    _attr_supported_features = LightEntityFeature.TRANSITION
 
     def set_state(self, params: dict):
         if self.param in params:
@@ -242,8 +238,8 @@ class XLightB1(XLight):
     _attr_max_mireds = 3  # warm
     _attr_effect_list = list(UIID22_MODES.keys())
     # support on/off, brightness, color_temp and RGB
-    _attr_supported_color_modes = {COLOR_MODE_COLOR_TEMP, COLOR_MODE_RGB}
-    _attr_supported_features = SUPPORT_EFFECT | SUPPORT_TRANSITION
+    _attr_supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.RGB}
+    _attr_supported_features = LightEntityFeature.EFFECT | LightEntityFeature.TRANSITION
 
     def set_state(self, params: dict):
         XLight.set_state(self, params)
@@ -251,15 +247,15 @@ class XLightB1(XLight):
         if "zyx_mode" in params:
             mode = params["zyx_mode"]  # 1-6
             if mode == 1:
-                self._attr_color_mode = COLOR_MODE_COLOR_TEMP
+                self._attr_color_mode = ColorMode.COLOR_TEMP
             else:
-                self._attr_color_mode = COLOR_MODE_RGB
+                self._attr_color_mode = ColorMode.RGB
             if mode >= 3:
                 self._attr_effect = self.effect_list[mode - 3]
             else:
                 self._attr_effect = None
 
-        if self.color_mode == COLOR_MODE_COLOR_TEMP:
+        if self.color_mode == ColorMode.COLOR_TEMP:
             # from 25 to 255
             cold = int(params["channel0"])
             warm = int(params["channel1"])
@@ -334,12 +330,12 @@ class XLightL1(XLight):
         "Music": {"mode": 12, "switch": "on"},
     }
 
-    _attr_color_mode = COLOR_MODE_RGB
+    _attr_color_mode = ColorMode.RGB
     _attr_effect_list = list(modes.keys())
 
     # support on/off, brightness, RGB
-    _attr_supported_color_modes = {COLOR_MODE_RGB}
-    _attr_supported_features = SUPPORT_EFFECT | SUPPORT_TRANSITION
+    _attr_supported_color_modes = {ColorMode.RGB}
+    _attr_supported_features = LightEntityFeature.EFFECT | LightEntityFeature.TRANSITION
 
     def set_state(self, params: dict):
         XLight.set_state(self, params)
@@ -769,11 +765,11 @@ class XLightB02(XLight):
     _attr_max_mireds: int = int(1000000 / 2200)  # 454
     _attr_min_mireds: int = int(1000000 / 6500)  # 153
 
-    _attr_color_mode = COLOR_MODE_COLOR_TEMP
+    _attr_color_mode = ColorMode.COLOR_TEMP
     _attr_effect_list = list(B02_MODE_PAYLOADS.keys())
     # support on/off, brightness and color_temp
-    _attr_supported_color_modes = {COLOR_MODE_COLOR_TEMP}
-    _attr_supported_features = SUPPORT_EFFECT | SUPPORT_TRANSITION
+    _attr_supported_color_modes = {ColorMode.COLOR_TEMP}
+    _attr_supported_features = LightEntityFeature.EFFECT | LightEntityFeature.TRANSITION
 
     # ewelink specs
     min_br = 1
@@ -846,7 +842,7 @@ B05_MODE_PAYLOADS = {
 class XLightB05B(XLightB02):
     _attr_effect_list = list(B05_MODE_PAYLOADS.keys())
     # support on/off, brightness, color_temp and RGB
-    _attr_supported_color_modes = {COLOR_MODE_COLOR_TEMP, COLOR_MODE_RGB}
+    _attr_supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.RGB}
     _attr_max_mireds = 500
     _attr_min_mireds = 153
 
@@ -858,9 +854,9 @@ class XLightB05B(XLightB02):
 
         effect = params["ltype"]
         if effect == "white":
-            self._attr_color_mode = COLOR_MODE_COLOR_TEMP
+            self._attr_color_mode = ColorMode.COLOR_TEMP
         else:
-            self._attr_color_mode = COLOR_MODE_RGB
+            self._attr_color_mode = ColorMode.RGB
 
         if effect in self.effect_list:
             self._attr_effect = effect
@@ -912,7 +908,7 @@ class XLightB05B(XLightB02):
                 },
             }
         if brightness:
-            if self.color_mode == COLOR_MODE_COLOR_TEMP:
+            if self.color_mode == ColorMode.COLOR_TEMP:
                 return self.get_params(brightness, self.color_temp, None, None)
             else:
                 return self.get_params(brightness, None, self.rgb_color, None)
@@ -939,8 +935,8 @@ class XLightGroup(XEntity, LightEntity):
 
     _attr_brightness = 0
     # support on/off and brightness
-    _attr_color_mode = COLOR_MODE_BRIGHTNESS
-    _attr_supported_color_modes = {COLOR_MODE_BRIGHTNESS}
+    _attr_color_mode = ColorMode.BRIGHTNESS
+    _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
     def set_state(self, params: dict):
         cnt = sum(
@@ -1010,7 +1006,7 @@ class XDiffuserLight(XEntity, LightEntity):
     params = {"lightswitch", "lightbright", "lightmode", "lightRcolor"}
 
     _attr_effect_list = ["Color Light", "RGB Color", "Night Light"]
-    _attr_supported_features = SUPPORT_EFFECT
+    _attr_supported_features = LightEntityFeature.EFFECT
 
     def set_state(self, params: dict):
         if "lightswitch" in params:
@@ -1023,16 +1019,16 @@ class XDiffuserLight(XEntity, LightEntity):
             mode = params["lightmode"]
             if mode == 1:
                 # support on/off
-                self._attr_color_mode = COLOR_MODE_ONOFF
-                self._attr_supported_color_modes = {COLOR_MODE_ONOFF}
+                self._attr_color_mode = ColorMode.ONOFF
+                self._attr_supported_color_modes = {ColorMode.ONOFF}
             elif mode == 2:
-                self._attr_color_mode = COLOR_MODE_RGB
+                self._attr_color_mode = ColorMode.RGB
                 # support on/off, brightness and RGB
-                self._attr_supported_color_modes = {COLOR_MODE_RGB}
+                self._attr_supported_color_modes = {ColorMode.RGB}
             elif mode == 3:
                 # support on/off and brightness
-                self._attr_color_mode = COLOR_MODE_BRIGHTNESS
-                self._attr_supported_color_modes = {COLOR_MODE_BRIGHTNESS}
+                self._attr_color_mode = ColorMode.BRIGHTNESS
+                self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
 
         if "lightRcolor" in params:
             self._attr_rgb_color = (
@@ -1077,7 +1073,7 @@ class XT5Light(XEntity, LightEntity):
     params = {"lightSwitch", "lightMode"}
 
     _attr_effect_list = ["0", "1", "2", "3", "4", "5", "6", "7"]
-    _attr_supported_features = SUPPORT_EFFECT
+    _attr_supported_features = LightEntityFeature.EFFECT
 
     def set_state(self, params: dict):
         if "lightSwitch" in params:

--- a/custom_components/sonoff/sensor.py
+++ b/custom_components/sonoff/sensor.py
@@ -8,13 +8,13 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    ELECTRIC_CURRENT_AMPERE,
-    ELECTRIC_POTENTIAL_VOLT,
-    ENERGY_KILO_WATT_HOUR,
     PERCENTAGE,
-    POWER_WATT,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-    TEMP_CELSIUS,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfTemperature,
 )
 from homeassistant.util import dt
 
@@ -47,14 +47,14 @@ DEVICE_CLASSES = {
 
 UNITS = {
     "battery": PERCENTAGE,
-    "battery_voltage": ELECTRIC_POTENTIAL_VOLT,
-    "current": ELECTRIC_CURRENT_AMPERE,
+    "battery_voltage": UnitOfElectricPotential.VOLT,
+    "current": UnitOfElectricCurrent.AMPERE,
     "humidity": PERCENTAGE,
-    "outdoor_temp": TEMP_CELSIUS,
-    "power": POWER_WATT,
+    "outdoor_temp": UnitOfTemperature.CELSIUS,
+    "power": UnitOfPower.WATT,
     "rssi": SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-    "temperature": TEMP_CELSIUS,
-    "voltage": ELECTRIC_POTENTIAL_VOLT,
+    "temperature": UnitOfTemperature.CELSIUS,
+    "voltage": UnitOfElectricPotential.VOLT,
 }
 
 
@@ -175,7 +175,7 @@ class XEnergySensor(XEntity, SensorEntity):
 
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_entity_registry_enabled_default = False
-    _attr_native_unit_of_measurement = ENERGY_KILO_WATT_HOUR
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_should_poll = True
 
@@ -257,7 +257,7 @@ class XEnergySensorPOWR3(XEnergySensor, SensorEntity):
 
 class XEnergyTotal(XSensor):
     _attr_device_class = SensorDeviceClass.ENERGY
-    _attr_native_unit_of_measurement = ENERGY_KILO_WATT_HOUR
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
     _attr_state_class = SensorStateClass.TOTAL
 
 
@@ -338,8 +338,7 @@ class XT5Action(XEntity, SensorEntity):
             self._attr_native_value = "touch"
             asyncio.create_task(self.clear_state())
 
-        # fix https://github.com/AlexxIT/SonoffLAN/issues/1252
-        if (slide := params.get("slide")) and len(params) == 1:
+        if slide := params.get("slide"):
             self._attr_native_value = f"slide_{slide}"
             asyncio.create_task(self.clear_state())
 

--- a/custom_components/sonoff/sensor.py
+++ b/custom_components/sonoff/sensor.py
@@ -338,7 +338,8 @@ class XT5Action(XEntity, SensorEntity):
             self._attr_native_value = "touch"
             asyncio.create_task(self.clear_state())
 
-        if slide := params.get("slide"):
+        # fix https://github.com/AlexxIT/SonoffLAN/issues/1252
+        if (slide := params.get("slide")) and len(params) == 1:
             self._attr_native_value = f"slide_{slide}"
             asyncio.create_task(self.clear_state())
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "Sonoff LAN",
-    "homeassistant": "2022.5.0",
+    "homeassistant": "2023.1.0",
     "render_readme": true
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
     "name": "Sonoff LAN",
+    "homeassistant": "2022.5.0",
     "render_readme": true
 }


### PR DESCRIPTION
Had these warnings in my logs, which are linked to changes in 2024.1 (https://developers.home-assistant.io/blog/2023/12/19/constant-deprecation/ and https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation/):
```py
2023-12-31 14:43:35.731 WARNING (MainThread) [homeassistant.components.climate.const] HVAC_MODE_AUTO was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.AUTO instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:35.737 WARNING (MainThread) [homeassistant.components.climate.const] HVAC_MODE_COOL was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.COOL instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:35.741 WARNING (MainThread) [homeassistant.components.climate.const] HVAC_MODE_DRY was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.DRY instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:35.745 WARNING (MainThread) [homeassistant.components.climate.const] HVAC_MODE_HEAT was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.HEAT instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:35.749 WARNING (MainThread) [homeassistant.components.climate.const] HVAC_MODE_HEAT_COOL was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.HEAT_COOL instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:35.753 WARNING (MainThread) [homeassistant.components.climate.const] HVAC_MODE_OFF was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use HVACMode.OFF instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:35.757 WARNING (MainThread) [homeassistant.components.climate.const] SUPPORT_PRESET_MODE was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use ClimateEntityFeature.PRESET_MODE instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:35.762 WARNING (MainThread) [homeassistant.components.climate.const] SUPPORT_TARGET_TEMPERATURE was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use ClimateEntityFeature.TARGET_TEMPERATURE instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:35.766 WARNING (MainThread) [homeassistant.components.climate.const] SUPPORT_TARGET_TEMPERATURE_RANGE was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use ClimateEntityFeature.TARGET_TEMPERATURE_RANGE instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:35.771 WARNING (MainThread) [homeassistant.const] TEMP_CELSIUS was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:35.778 WARNING (MainThread) [homeassistant.components.fan] SUPPORT_PRESET_MODE was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use FanEntityFeature.PRESET_MODE instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:35.782 WARNING (MainThread) [homeassistant.components.fan] SUPPORT_SET_SPEED was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use FanEntityFeature.SET_SPEED instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:35.786 WARNING (MainThread) [homeassistant.components.fan] SUPPORT_PRESET_MODE was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use FanEntityFeature.PRESET_MODE instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:35.791 WARNING (MainThread) [homeassistant.components.fan] SUPPORT_SET_SPEED was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use FanEntityFeature.SET_SPEED instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:35.805 WARNING (MainThread) [homeassistant.const] ELECTRIC_CURRENT_AMPERE was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfElectricCurrent.AMPERE instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:35.809 WARNING (MainThread) [homeassistant.const] ELECTRIC_POTENTIAL_VOLT was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfElectricPotential.VOLT instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:35.814 WARNING (MainThread) [homeassistant.const] ENERGY_KILO_WATT_HOUR was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfEnergy.KILO_WATT_HOUR instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:35.819 WARNING (MainThread) [homeassistant.const] POWER_WATT was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfPower.WATT instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:35.824 WARNING (MainThread) [homeassistant.const] TEMP_CELSIUS was used from sonoff, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead, please create a bug report at https://github.com/AlexxIT/SonoffLAN/issues
2023-12-31 14:43:55.538 WARNING (MainThread) [homeassistant.components.light] Entity sonoff.sonoff_1000f7eeca (<class 'custom_components.sonoff.light.XLightL1'>) is using deprecated supported features values which will be removed in HA Core 2025.1. Instead it should use <LightEntityFeature.EFFECT|TRANSITION: 36> and color modes, please create a bug report at /api/sonoff/a97f87d0-f357-4739-b9c8-641792345b61 and reference https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation
```

With the changes, all warnings are gone. Tested locally, runs fine. I don't have a Sonoff climate device - someone should test this.

Needs HA >2022.5 because of https://developers.home-assistant.io/blog/2022/04/02/support-constants-deprecation/ and https://developers.home-assistant.io/blog/2022/05/03/constants-deprecations/.

Should fix #1278 