### PR TITLE
Show TX5 ambient light effect names. Ref. AlexxIT#1247

### DIFF
--- a/custom_components/sonoff/light.py
+++ b/custom_components/sonoff/light.py
@@ -1072,7 +1072,7 @@ class XDiffuserLight(XEntity, LightEntity):
 class XT5Light(XEntity, LightEntity):
     params = {"lightSwitch", "lightMode"}
 
-    _attr_effect_list = ["0", "1", "2", "3", "4", "5", "6", "7"]
+    _attr_effect_list = ["Night Light", "Party", "Leisure", "Color", "Childhood", "Wiper", "Fairy", "Starburst"]
     _attr_supported_features = LightEntityFeature.EFFECT
 
     def set_state(self, params: dict):
@@ -1087,8 +1087,8 @@ class XT5Light(XEntity, LightEntity):
     ) -> None:
         params = {}
 
-        if effect and effect != "0":
-            params["lightMode"] = int(effect)
+        if effect:
+            params["lightMode"] = self._attr_effect_list.index(effect)
 
         if not params:
             params["lightSwitch"] = "on"


### PR DESCRIPTION
It shows TX5 ambient light effect names instead of numbers.

![image](https://github.com/AlexxIT/SonoffLAN/assets/6662129/6b9d70df-b9b4-43e5-9749-efc78397fe5f)
