### PR TITLE
Support config params for XT5 and light fixes

### DIFF
--- a/custom_components/sonoff/__init__.py
+++ b/custom_components/sonoff/__init__.py
@@ -49,6 +49,7 @@ PLATFORMS = [
     "fan",
     "light",
     "remote",
+    "select",
     "sensor",
     "switch",
     "number",

--- a/custom_components/sonoff/core/devices.py
+++ b/custom_components/sonoff/core/devices.py
@@ -36,10 +36,12 @@ from ..light import (
     XLightL1,
     XLightL3,
     XT5Light,
+    XT5LightStatusLight,
     XZigbeeLight,
 )
 from ..number import XPulseWidth
 from ..remote import XRemote
+from ..select import XT5Select
 from ..sensor import (
     XEnergySensor,
     XHumidityTH,
@@ -61,6 +63,7 @@ from ..switch import (
     XSwitches,
     XSwitchTH,
     XToggle,
+    XToggleNum,
     XZigbeeSwitches,
     XSwitchPOWR3,
     XDetach,
@@ -111,6 +114,8 @@ Battery = spec(XSensor, param="battery")
 LED = spec(XToggle, param="sledOnline", uid="led", enabled=False)
 RSSI = spec(XSensor, param="rssi", enabled=False)
 PULSE = spec(XToggle, param="pulse", enabled=False)
+SHOCK = spec(XToggleNum, param="shock")
+NETWORK_INDICATOR = spec(LED, name="Network indicator", enabled=False)
 
 SPEC_SWITCH = [XSwitch, LED, RSSI, PULSE, XPulseWidth]
 SPEC_1CH = [Switch1, LED, RSSI]
@@ -354,11 +359,111 @@ DEVICES = {
     # https://github.com/AlexxIT/SonoffLAN/issues/984
     195: [XTemperatureTH],  # NSPanel Pro
     # https://github.com/AlexxIT/SonoffLAN/issues/1183
-    209: [Switch1, XT5Light, XT5Action],  # T5-1C-86
-    210: [Switch1, Switch2, XT5Light, XT5Action],  # T5-2C-86
-    211: [Switch1, Switch2, Switch3, XT5Light, XT5Action],  # T5-3C-86
+    209: [  # T5-1C-86
+        Switch1,
+        XT5Light,
+        SHOCK, NETWORK_INDICATOR,
+
+        spec(XT5LightStatusLight, param="onEffects", uid="onEffectsStatus", name="On effects [status]",
+             icon="mdi:lightbulb-alert"),
+        spec(XT5LightStatusLight, param="offEffects", uid="offEffectsStatus", name="Off effects [status]",
+             icon="mdi:lightbulb-alert-outline"),
+
+        spec(XT5Select, param="onEffects", property="lightEffect", effect_name="Light", effect_count=5,
+             uid="onEffectsLight", name="On effects [light]", icon="mdi:lightbulb-on"),
+        spec(XT5Select, param="offEffects", property="lightEffect", effect_name="Light", effect_count=5,
+             uid="offEffectsLight", name="Off effects [light]", icon="mdi:lightbulb-on-outline"),
+        spec(XT5Select, param="preEffects", property="lightEffect", effect_name="Light", effect_count=5,
+             uid="preEffectsLight", name="Preview effects [light]", icon="mdi:lightbulb-on"),
+
+        spec(XT5Select, param="onEffects", property="soundEffect", effect_name="Sound", effect_count=5,
+             uid="onEffectsSound", name="On effects [sound]", icon="mdi:alarm-light"),
+        spec(XT5Select, param="offEffects", property="soundEffect", effect_name="Sound", effect_count=5,
+             uid="offEffectsSound", name="Off effects [sound]", icon="mdi:alarm-light-outline"),
+        spec(XT5Select, param="preEffects", property="soundEffect", effect_name="Sound", effect_count=5,
+             uid="preEffectsSound", name="Preview effects [sound]", icon="mdi:alarm-light"),
+
+        XT5Action
+    ],
+    210: [  # T5-2C-86
+        Switch1, Switch2,
+        XT5Light,
+        SHOCK, NETWORK_INDICATOR,
+
+        spec(XT5LightStatusLight, param="onEffects", uid="onEffectsStatus", name="On effects [status]",
+             icon="mdi:lightbulb-alert"),
+        spec(XT5LightStatusLight, param="offEffects", uid="offEffectsStatus", name="Off effects [status]",
+             icon="mdi:lightbulb-alert-outline"),
+
+        spec(XT5Select, param="onEffects", property="lightEffect", effect_name="Light", effect_count=5,
+             uid="onEffectsLight", name="On effects [light]", icon="mdi:lightbulb-on"),
+        spec(XT5Select, param="offEffects", property="lightEffect", effect_name="Light", effect_count=5,
+             uid="offEffectsLight", name="Off effects [light]", icon="mdi:lightbulb-on-outline"),
+        spec(XT5Select, param="preEffects", property="lightEffect", effect_name="Light", effect_count=5,
+             uid="preEffectsLight", name="Preview effects [light]", icon="mdi:lightbulb-on"),
+
+        spec(XT5Select, param="onEffects", property="soundEffect", effect_name="Sound", effect_count=5,
+             uid="onEffectsSound", name="On effects [sound]", icon="mdi:alarm-light"),
+        spec(XT5Select, param="offEffects", property="soundEffect", effect_name="Sound", effect_count=5,
+             uid="offEffectsSound", name="Off effects [sound]", icon="mdi:alarm-light-outline"),
+        spec(XT5Select, param="preEffects", property="soundEffect", effect_name="Sound", effect_count=5,
+             uid="preEffectsSound", name="Preview effects [sound]", icon="mdi:alarm-light"),
+
+        XT5Action
+    ],
+    211: [  # T5-3C-86
+        Switch1, Switch2, Switch3,
+        XT5Light,
+        SHOCK, NETWORK_INDICATOR,
+
+        spec(XT5LightStatusLight, param="onEffects", uid="onEffectsStatus", name="On effects [status]",
+             icon="mdi:lightbulb-alert"),
+        spec(XT5LightStatusLight, param="offEffects", uid="offEffectsStatus", name="Off effects [status]",
+             icon="mdi:lightbulb-alert-outline"),
+
+        spec(XT5Select, param="onEffects", property="lightEffect", effect_name="Light", effect_count=5,
+             uid="onEffectsLight", name="On effects [light]", icon="mdi:lightbulb-on"),
+        spec(XT5Select, param="offEffects", property="lightEffect", effect_name="Light", effect_count=5,
+             uid="offEffectsLight", name="Off effects [light]", icon="mdi:lightbulb-on-outline"),
+        spec(XT5Select, param="preEffects", property="lightEffect", effect_name="Light", effect_count=5,
+             uid="preEffectsLight", name="Preview effects [light]", icon="mdi:lightbulb-on"),
+
+        spec(XT5Select, param="onEffects", property="soundEffect", effect_name="Sound", effect_count=5,
+             uid="onEffectsSound", name="On effects [sound]", icon="mdi:alarm-light"),
+        spec(XT5Select, param="offEffects", property="soundEffect", effect_name="Sound", effect_count=5,
+             uid="offEffectsSound", name="Off effects [sound]", icon="mdi:alarm-light-outline"),
+        spec(XT5Select, param="preEffects", property="soundEffect", effect_name="Sound", effect_count=5,
+             uid="preEffectsSound", name="Preview effects [sound]", icon="mdi:alarm-light"),
+
+        XT5Action
+    ],
     # https://github.com/AlexxIT/SonoffLAN/issues/1251
-    212: [Switch1, Switch2, Switch3, Switch4, XT5Light, XT5Action],  # T5-4C-86
+    212: [  # T5-4C-86
+        Switch1, Switch2, Switch3, Switch4,
+        XT5Light,
+        SHOCK, NETWORK_INDICATOR,
+
+        spec(XT5LightStatusLight, param="onEffects", uid="onEffectsStatus", name="On effects [status]",
+             icon="mdi:lightbulb-alert"),
+        spec(XT5LightStatusLight, param="offEffects", uid="offEffectsStatus", name="Off effects [status]",
+             icon="mdi:lightbulb-alert-outline"),
+
+        spec(XT5Select, param="onEffects", property="lightEffect", effect_name="Light", effect_count=5,
+             uid="onEffectsLight", name="On effects [light]", icon="mdi:lightbulb-on"),
+        spec(XT5Select, param="offEffects", property="lightEffect", effect_name="Light", effect_count=5,
+             uid="offEffectsLight", name="Off effects [light]", icon="mdi:lightbulb-on-outline"),
+        spec(XT5Select, param="preEffects", property="lightEffect", effect_name="Light", effect_count=5,
+             uid="preEffectsLight", name="Preview effects [light]", icon="mdi:lightbulb-on"),
+
+        spec(XT5Select, param="onEffects", property="soundEffect", effect_name="Sound", effect_count=5,
+             uid="onEffectsSound", name="On effects [sound]", icon="mdi:alarm-light"),
+        spec(XT5Select, param="offEffects", property="soundEffect", effect_name="Sound", effect_count=5,
+             uid="offEffectsSound", name="Off effects [sound]", icon="mdi:alarm-light-outline"),
+        spec(XT5Select, param="preEffects", property="soundEffect", effect_name="Sound", effect_count=5,
+             uid="preEffectsSound", name="Preview effects [sound]", icon="mdi:alarm-light"),
+
+        XT5Action
+    ],
     1000: [XRemoteButton, Battery],  # zigbee_ON_OFF_SWITCH_1000
     # https://github.com/AlexxIT/SonoffLAN/issues/1195
     1256: [spec(XSwitch)],  # ZCL_HA_DEVICEID_ON_OFF_LIGHT

--- a/custom_components/sonoff/core/entity.py
+++ b/custom_components/sonoff/core/entity.py
@@ -15,12 +15,14 @@ ENTITY_CATEGORIES = {
     "rssi": EntityCategory.DIAGNOSTIC,
     "pulse": EntityCategory.CONFIG,
     "pulseWidth": EntityCategory.CONFIG,
+    "shock": EntityCategory.CONFIG,
 }
 
 ICONS = {
     "dusty": "mdi:cloud",
     "led": "mdi:led-off",
     "noise": "mdi:bell-ring",
+    "shock": "mdi:vibrate",
 }
 
 NAMES = {
@@ -28,6 +30,7 @@ NAMES = {
     "rssi": "RSSI",
     "pulse": "INCHING",
     "pulseWidth": "INCHING Duration",
+    "shock": "Vibrate",
 }
 
 

--- a/custom_components/sonoff/light.py
+++ b/custom_components/sonoff/light.py
@@ -343,7 +343,7 @@ class XLightL1(XLight):
 
         if "bright" in params:
             self._attr_brightness = conv(params["bright"], 1, 100, 1, 255)
-        if "colorR" in params and "colorG" in params and "colorB":
+        if "colorR" in params and "colorG" in params and "colorB" in params:
             self._attr_rgb_color = (
                 params["colorR"],
                 params["colorG"],

--- a/custom_components/sonoff/light.py
+++ b/custom_components/sonoff/light.py
@@ -1146,6 +1146,7 @@ class XT5Light(XEntity, LightEntity):
         "Fairy",
         "Starburst",
     ]
+    _attr_supported_color_modes = {ColorMode.ONOFF}
     _attr_supported_features = LightEntityFeature.EFFECT
 
     def set_state(self, params: dict):

--- a/custom_components/sonoff/select.py
+++ b/custom_components/sonoff/select.py
@@ -1,0 +1,57 @@
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.const import EntityCategory
+
+from .core.const import DOMAIN
+from .core.entity import XEntity
+from .core.ewelink import SIGNAL_ADD_ENTITIES, XRegistry, XDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, config_entry, add_entities):
+    ewelink: XRegistry = hass.data[DOMAIN][config_entry.entry_id]
+    ewelink.dispatcher_connect(
+        SIGNAL_ADD_ENTITIES,
+        lambda x: add_entities([e for e in x if isinstance(e, SelectEntity)]),
+    )
+
+
+class XT5Select(XEntity, SelectEntity):
+    entity_category = EntityCategory.CONFIG
+    _attr_current_option = None
+    _attr_options = None
+
+    property: str = None
+    effect_name: str = None
+    effect_count: int = None
+
+    def __init__(self, ewelink: XRegistry, device: XDevice):
+        self._attr_options = ["None"]
+        self._attr_options.extend(map(lambda x: f"{self.effect_name} {x+1}", range(self.effect_count)))
+
+        super().__init__(ewelink, device)
+
+    def set_state(self, params: dict):
+        effect_params = params[self.param]
+        cache = self.device["params"][self.param]
+        if cache != effect_params:
+            cache.update(effect_params)
+
+        if self.property in effect_params:
+            self._attr_current_option = self._attr_options[effect_params[self.property]]
+
+    def get_params(self, option: str) -> dict:
+        params = self.device['params'][self.param]
+        params[self.property] = self._attr_options.index(option or self._attr_current_option)
+        return params
+
+    async def async_select_option(self, option: str) -> None:
+        """Update the current selected option."""
+        params = self.get_params(option)
+        self._attr_current_option = option
+
+        await self.ewelink.send(self.device, {
+            self.param: params
+        })

--- a/custom_components/sonoff/switch.py
+++ b/custom_components/sonoff/switch.py
@@ -133,3 +133,16 @@ class XDetach(XEntity, SwitchEntity):
 
     async def async_turn_off(self):
         await self.ewelink.send_cloud(self.device, {"relaySeparation": 0})
+
+
+# noinspection PyAbstractClass
+class XToggleNum(XEntity, SwitchEntity):
+    def set_state(self, params: dict):
+        self.device["params"][self.param] = params[self.param]
+        self._attr_is_on = params[self.param] == 1
+
+    async def async_turn_on(self):
+        await self.ewelink.send(self.device, {self.param: 1})
+
+    async def async_turn_off(self):
+        await self.ewelink.send(self.device, {self.param: 0})


### PR DESCRIPTION
 feat: Support configs for XT5
-  Network indicator [LED]
-  Vibration [XToggleNum]
-  On/Off/Preview sound and light effects [XT5Select]
-  On/Off state indicator (color and position) [XT5LightStatusLight]

Also, two fixes:
 - fix: Fix XT5Light warning [(<class 'custom_components.sonoff.light.XT5Light'>) does not set supported color modes, this will stop working in Home Assistant Core 2025.3
 - fix: Fix XLightL1 incomplete statement