### PR TITLE
Fix energy histories for SPM-4Relay (GD32-SM4)

### DIFF
--- a/custom_components/sonoff/core/devices.py
+++ b/custom_components/sonoff/core/devices.py
@@ -272,13 +272,13 @@ DEVICES = {
         ),
         spec(
             XEnergySensorDualR3,
-            param="kwhHistories_01",
+            param="kwhHistories_02",
             uid="energy_3",
             get_params={"getKwh_02": 2},
         ),
         spec(
             XEnergySensorDualR3,
-            param="kwhHistories_01",
+            param="kwhHistories_03",
             uid="energy_4",
             get_params={"getKwh_03": 2},
         ),


### PR DESCRIPTION
This pull request corrects historical parameters within the energy sensor configuration for SPM-4Relay (GD32-SM4) device