### PR TITLE
Fix(translations): fix 'insert' translation typo and add missing country_code translation

### DIFF
--- a/custom_components/sonoff/translations/pt-BR.json
+++ b/custom_components/sonoff/translations/pt-BR.json
@@ -12,7 +12,8 @@
         "description": "Insira a sua [conta eWeLink](https://www.ewelink.cc/en/)",
         "data": {
           "username": "E-mail ou telefone (use qualquer um para o modo DIY)",
-          "password": "Senha (deixe em branco para o modo DIY)"
+          "password": "Senha (deixe em branco para o modo DIY)",
+          "country_code": "Código do país (deixe em branco para escolha automática)"
         }
       }
     }

--- a/custom_components/sonoff/translations/pt.json
+++ b/custom_components/sonoff/translations/pt.json
@@ -9,10 +9,11 @@
     },
     "step": {
       "user": {
-        "description": "Insirir credenciais da [conta eWeLink](https://www.ewelink.cc/en/)",
+        "description": "Inserir credenciais da [conta eWeLink](https://www.ewelink.cc/en/)",
         "data": {
           "username": "Email ou telefone (usar qualquer um para o modo DIY)",
-          "password": "Senha (deixar em branco para o modo DIY)"
+          "password": "Senha (deixar em branco para o modo DIY)",
+          "country_code": "Código do país (deixar em branco para escolha automática)"
         }
       }
     }


### PR DESCRIPTION
In this simple PR I fixed a typo, added a missing PT and PT-BR translation.