### PR TITLE
Add support for T5 Ultimate Motor Mode

### DIFF
--- a/custom_components/sonoff/core/devices.py
+++ b/custom_components/sonoff/core/devices.py
@@ -74,6 +74,7 @@ from ..switch import (
     XSwitches,
     XToggle,
     XZigbeeSwitches,
+    XT5WorkMode,
 )
 
 # supported custom device_class
@@ -384,6 +385,7 @@ DEVICES = {
         XT5Alarm,
         XT5Bell,
         XCoverT5,
+        XT5WorkMode,
     ],  # T5-3C-86
     # https://github.com/AlexxIT/SonoffLAN/issues/1251
     212: [

--- a/custom_components/sonoff/core/devices.py
+++ b/custom_components/sonoff/core/devices.py
@@ -29,7 +29,7 @@ from ..binary_sensor import (
 from ..button import XT5Button
 from ..climate import XClimateNS, XClimateTH, XThermostat
 from ..core.entity import XEntity
-from ..cover import XCover, XCover91, XCoverDualR3, XZigbeeCover
+from ..cover import XCover, XCover91, XCoverDualR3, XCoverT5, XZigbeeCover
 from ..fan import XDiffuserFan, XFan, XFanDualR3, XToggleFan
 from ..light import (
     XDiffuserLight,
@@ -383,6 +383,7 @@ DEVICES = {
         XT5Action,
         XT5Alarm,
         XT5Bell,
+        XCoverT5,
     ],  # T5-3C-86
     # https://github.com/AlexxIT/SonoffLAN/issues/1251
     212: [

--- a/custom_components/sonoff/cover.py
+++ b/custom_components/sonoff/cover.py
@@ -160,3 +160,38 @@ class XCover91(XEntity, CoverEntity):
 
     async def async_close_cover(self, **kwargs):
         await self.ewelink.send(self.device, {self.param: 3})
+
+
+# noinspection PyAbstractClass
+class XCoverT5(XCover):
+    params = {"electromotor", "percentageControl"}
+
+    _attr_is_closed = None  # unknown state
+
+    def set_state(self, params: dict):
+        if "percentageControl" in params:
+            self._attr_current_cover_position = 100 - params["percentageControl"]
+            self._attr_is_closed = self._attr_current_cover_position == 100
+
+        if "electromotor" in params:
+            if params["electromotor"] == 1:  # stop
+                self._attr_is_opening = False
+                self._attr_is_closing = False
+            elif params["electromotor"] == 0:  # open
+                self._attr_is_opening = True
+                self._attr_is_closing = False
+            elif params["electromotor"] == 2:  # close
+                self._attr_is_opening = False
+                self._attr_is_closing = True
+
+    async def async_stop_cover(self, **kwargs):
+        await self.ewelink.send(self.device, {"electromotor": 1})
+
+    async def async_open_cover(self, **kwargs):
+        await self.ewelink.send(self.device, {"electromotor": 0})
+
+    async def async_close_cover(self, **kwargs):
+        await self.ewelink.send(self.device, {"electromotor": 2})
+
+    async def async_set_cover_position(self, position: int, **kwargs):
+        await self.ewelink.send(self.device, {"percentageControl": 100 - position})

--- a/custom_components/sonoff/cover.py
+++ b/custom_components/sonoff/cover.py
@@ -171,7 +171,7 @@ class XCoverT5(XCover):
     _attr_is_closed = None  # unknown state
 
     def set_state(self, params: dict):
-        if "percentageControl" in params and calibState is True:
+        if "percentageControl" in params and params["calibState"] is True:
             self._attr_current_cover_position = 100 - params["percentageControl"]
             self._attr_is_closed = self._attr_current_cover_position == 0
 

--- a/custom_components/sonoff/cover.py
+++ b/custom_components/sonoff/cover.py
@@ -171,9 +171,9 @@ class XCoverT5(XCover):
     _attr_is_closed = None  # unknown state
 
     def set_state(self, params: dict):
-        if "percentageControl" in params:
+        if "percentageControl" in params and calibState is True:
             self._attr_current_cover_position = 100 - params["percentageControl"]
-            self._attr_is_closed = self._attr_current_cover_position == 100
+            self._attr_is_closed = self._attr_current_cover_position == 0
 
         if "electromotor" in params:
             if params["electromotor"] == 1:  # stop

--- a/custom_components/sonoff/cover.py
+++ b/custom_components/sonoff/cover.py
@@ -166,6 +166,8 @@ class XCover91(XEntity, CoverEntity):
 class XCoverT5(XCover):
     params = {"electromotor", "percentageControl"}
 
+    _attr_entity_registry_enabled_default = False
+
     _attr_is_closed = None  # unknown state
 
     def set_state(self, params: dict):

--- a/custom_components/sonoff/switch.py
+++ b/custom_components/sonoff/switch.py
@@ -134,7 +134,6 @@ class XDetach(XEntity, SwitchEntity):
     async def async_turn_off(self):
         await self.ewelink.send_cloud(self.device, {"relaySeparation": 0})
 
-
 class XBoolSwitch(XEntity, SwitchEntity):
     params = {"switch"}
 
@@ -146,3 +145,18 @@ class XBoolSwitch(XEntity, SwitchEntity):
 
     async def async_turn_off(self):
         await self.ewelink.send(self.device, {"switch": False})
+
+class XT5WorkMode(XEntity, SwitchEntity):
+    params = {"workMode"}
+    uid = "curtain_mode"
+
+    _attr_entity_registry_enabled_default = False
+
+    def set_state(self, params: dict):
+        self._attr_is_on = params["workMode"] == 2
+
+    async def async_turn_on(self, *args, **kwargs):
+        await self.ewelink.send(self.device, {"workMode": 2})
+
+    async def async_turn_off(self):
+        await self.ewelink.send(self.device, {"workMode": 1})


### PR DESCRIPTION
Hello! This pull request implements support for the T5 Ultimate's Motor Mode.

I'm yet to find a way of managing the calibration, I suppose this might only work through ewelink. But any nudges in the right direction will be much appreciated.

This solves #1388 and some other duplicate issues

I'm not familiarized with this codebase so I would appreciate support on the following:

- ~~Automatically disabling normal switch entities when motor mode is on.~~
- Code conventions/Variable names (not clear if we should call the class XCoverT5 or XT5Cover)

In any case, this PR should be ready to go. It's been tested thoroughly and seems to work perfectly. If more T5 Ultimate features are missing I would love to help!