### PR TITLE
Fix the issue about startup status could not be updated and add suppo…

### DIFF
--- a/custom_components/sonoff/core/devices.py
+++ b/custom_components/sonoff/core/devices.py
@@ -441,6 +441,7 @@ DEVICES = {
             get_params={"getHoursKwh": {"start": 0, "end": 24 * 30 - 1}},
         ),
     ],
+    191: [*SPEC_1CH, Startup1],
     # NSPanel Pro, https://github.com/AlexxIT/SonoffLAN/issues/984
     195: [XTemperatureTH, XPanelAlarm, XPanelBuzzer, XPanelScreen],
     # Sonoff TX ULTIMATE T5-1C-86, https://github.com/AlexxIT/SonoffLAN/issues/1183

--- a/custom_components/sonoff/select.py
+++ b/custom_components/sonoff/select.py
@@ -16,7 +16,7 @@ async def async_setup_entry(hass, config_entry, add_entities):
 
 
 class XSelectStartup(XEntity, SelectEntity):
-    params = {"startup"}
+    params = {"configure"}
     channel: int = 0
 
     get_params = {"configure": "get"}
@@ -49,7 +49,7 @@ class XSelectStartup(XEntity, SelectEntity):
     def set_state(self, params: dict):
         # Just update _attr_current_option based on what the device reports
         if "params" in self.device and isinstance(self.device["params"], dict):
-            configure_list = self.device["params"].get("configure")
+            configure_list = params.get("configure")
             if isinstance(configure_list, list):
                 for item in configure_list:
                     if item.get("outlet") == self.channel:


### PR DESCRIPTION
## Summary
1. Startup(Power-on State) state fails to sync to Home Assistant.
2. Add support of uiid 191 (single-channel switch with Startup feature)

## Device data example
1. For reference, this is my uiid191 device data from eWeLink cloud.
````json
{
    "itemType": 1,
    "itemData": {
        "name": "UIID191",
        "deviceid": "10018dc44e",
        "apikey": "be1dc97c-a6df-4850-8b9b-c37ab59a7f1a",
        "extra": {
            "model": "CK-BL602-4SW-HS-02",
            "ui": "WiFi/2.4G单通道插座-支持轻智能网关",
            "uiid": 191,
            "description": "2022年10月14日 蒲玖云 KWW220126",
            "manufacturer": "深圳酷宅科技有限公司",
            "mac": "d0:27:03:1b:8d:a4",
            "apmac": "d0:27:03:1b:8d:a5",
            "modelInfo": "61c42afb1c15aed82a867a4d",
            "brandId": "59e0dbc25c1af3a660cc1ac0"
        },
        "brandName": "coolkit",
        "brandLogo": "",
        "showBrand": false,
        "productModel": "CK-BL602-4SW-HS-02(191)",
        "tags": {
            "m_7f1a_7199": "on",
            "disable_timers": [
                {
                    "mId": "e754b1e4-c997-2e6d-4432-7bd86d6e4da4",
                    "type": "repeat",
                    "at": "0 1 * * 0,1,2,3,4,5,6",
                    "coolkit_timer_type": "repeat",
                    "enabled": 0,
                    "do": {
                        "switch": "off",
                        "outlet": 0
                    }
                }
            ]
        },
        "devConfig": {},
        "settings": {
            "opsNotify": 0,
            "opsHistory": 1,
            "alarmNotify": 1,
            "wxAlarmNotify": 0,
            "wxOpsNotify": 0,
            "wxDoorbellNotify": 0,
            "appDoorbellNotify": 1
        },
        "devGroups": [],
        "family": {
            "familyid": "68c4544a46e3e4dcee348e60",
            "index": 5,
            "members": [],
            "guests": []
        },
        "shareTo": [],
        "devicekey": "78d97a0c-0471-435a-a197-bdf8b4759558",
        "online": true,
        "params": {
            "bindInfos": {
                "hiLink": [],
                "miot": [],
                "gaction": [
                    "be1dc97c-a6df-4850-8b9b-c37ab59a7f1a_ewelinkGoogleHome"
                ]
            },
            "version": 8,
            "rssi": -18,
            "fwVersion": "1.1.0",
            "switches": [
                {
                    "switch": "off",
                    "outlet": 0
                },
                {
                    "switch": "off",
                    "outlet": 1
                },
                {
                    "switch": "off",
                    "outlet": 2
                },
                {
                    "switch": "off",
                    "outlet": 3
                }
            ],
            "configure": [
                {
                    "startup": "stay",
                    "outlet": 0
                }
            ],
            "pulses": [
                {
                    "pulse": "off",
                    "switch": "off",
                    "outlet": 0,
                    "width": 0
                },
                {
                    "pulse": "off",
                    "switch": "off",
                    "outlet": 1,
                    "width": 0
                },
                {
                    "pulse": "off",
                    "switch": "off",
                    "outlet": 2,
                    "width": 0
                },
                {
                    "pulse": "off",
                    "switch": "off",
                    "outlet": 3,
                    "width": 0
                }
            ],
            "remoteCtrlList": [
                {
                    "outlet": 0,
                    "addr": []
                },
                {
                    "outlet": 1,
                    "addr": []
                },
                {
                    "outlet": 2,
                    "addr": []
                },
                {
                    "outlet": 3,
                    "addr": []
                }
            ],
            "lightScenes_0": [
                {
                    "index": 0,
                    "switch": "on"
                }
            ],
            "lightScenes_1": [],
            "lightScenes_2": [],
            "lightScenes_3": [],
            "sledOnline": "on",
            "ssid": "荣耀路由",
            "bssid": "90:17:c8:53:18:b8",
            "addr": "e0ed88e3",
            "timers": [],
            "subDevices": [],
            "zled": "on"
        },
        "isSupportGroup": true,
        "isSupportedOnMP": true,
        "isSupportChannelSplit": false,
        "deviceFeature": {}
    },
    "index": 5
}
````
2. Device diagnostic data downloaded from HomeAssistant
````json
{
  "home_assistant": {
    "installation_type": "Unsupported Third Party Container",
    "version": "2026.1.0.dev0",
    "dev": true,
    "hassio": false,
    "virtualenv": true,
    "python_version": "3.13.11",
    "docker": true,
    "arch": "x86_64",
    "timezone": "Asia/Shanghai",
    "os_name": "Linux",
    "os_version": "6.17.0-8-generic",
    "run_as_root": false
  },
  "custom_components": {},
  "integration_manifest": {
    "domain": "sonoff",
    "name": "Sonoff",
    "codeowners": [
      "AlexxIT"
    ],
    "config_flow": true,
    "dependencies": [
      "http",
      "zeroconf"
    ],
    "documentation": "https://github.com/AlexxIT/SonoffLAN",
    "iot_class": "local_push",
    "issue_tracker": "https://github.com/AlexxIT/SonoffLAN/issues",
    "requirements": [
      "pycryptodome>=3.6.6"
    ],
    "version": "3.9.3",
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 0.00020768604008480906
    },
    "01KFAJN6WNQSA4G1V7EC5BN2F1": {
      "wait_import_platforms": -0.0007614450296387076,
      "wait_base_component": -0.0008612609817646444,
      "config_entry_setup": 1.5605076920473948
    }
  },
  "data": {
    "version": "fb36ad5",
    "cloud_auth": true,
    "config": null,
    "options": {},
    "errors": [],
    "device": {
      "uiid": 191,
      "params": {
        "bindInfos": "***",
        "version": 8,
        "rssi": -28,
        "fwVersion": "1.1.0",
        "switches": [
          {
            "switch": "on",
            "outlet": 0
          },
          {
            "switch": "on",
            "outlet": 1
          },
          {
            "switch": "on",
            "outlet": 2
          },
          {
            "switch": "on",
            "outlet": 3
          }
        ],
        "configure": [
          {
            "startup": "stay",
            "outlet": 0
          },
          {
            "startup": "off",
            "outlet": 1
          },
          {
            "startup": "off",
            "outlet": 2
          },
          {
            "startup": "off",
            "outlet": 3
          }
        ],
        "pulses": [
          {
            "pulse": "off",
            "switch": "off",
            "outlet": 0,
            "width": 0
          },
          {
            "pulse": "off",
            "switch": "off",
            "outlet": 1,
            "width": 0
          },
          {
            "pulse": "off",
            "switch": "off",
            "outlet": 2,
            "width": 0
          },
          {
            "pulse": "off",
            "switch": "off",
            "outlet": 3,
            "width": 0
          }
        ],
        "remoteCtrlList": [
          {
            "outlet": 0,
            "addr": []
          },
          {
            "outlet": 1,
            "addr": []
          },
          {
            "outlet": 2,
            "addr": []
          },
          {
            "outlet": 3,
            "addr": []
          }
        ],
        "lightScenes_0": [
          {
            "index": 0,
            "switch": "on"
          }
        ],
        "lightScenes_1": [],
        "lightScenes_2": [],
        "lightScenes_3": [],
        "sledOnline": "on",
        "ssid": "***",
        "bssid": "***",
        "addr": "e0ed88e3",
        "timers": "***",
        "subDevices": [],
        "zled": "on"
      },
      "model": "CK-BL602-4SW-HS-02(191)",
      "online": true,
      "local": null,
      "localtype": null,
      "host": null,
      "deviceid": "10018dc44e"
    }
  },
  "issues": []
}
````

## Test
Uiid 191 Single-channel device with Power-on state feature，See the video below for details.

https://github.com/user-attachments/assets/d62df24b-7e56-4809-8db9-545c4bc3c988