### PR TITLE
Fix some bugs in TRVZB

### DIFF
--- a/custom_components/sonoff/climate.py
+++ b/custom_components/sonoff/climate.py
@@ -331,8 +331,8 @@ class XThermostatTRVZB(XEntity, ClimateEntity):
 
     _attr_hvac_mode = None
     _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF, HVACMode.AUTO]
-    _attr_max_temp = 45
-    _attr_min_temp = 5
+    _attr_max_temp = 35
+    _attr_min_temp = 4
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 0.5
 
@@ -361,7 +361,7 @@ class XThermostatTRVZB(XEntity, ClimateEntity):
             self._attr_target_temperature = cache["curTargetTemp"] * 0.1
 
         if "temperature" in cache:
-            self._attr_current_temperature = cache["temperature"] * 0.1
+            self._attr_current_temperature = int(cache["temperature"]) * 0.1
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         await self.async_set_temperature(hvac_mode=hvac_mode)


### PR DESCRIPTION
## Summary
1. In the eWeLink app, the target temperature ("Set at") for TRVZB should be in the range 4–35 °C.
2. When TRVZB reports the current temperature, the reported value is a string; the handling in `custom_components/sonoff/climate.py` at lines 364 causes a TypeError.
````python
if "temperature" in cache:
    self._attr_current_temperature = cache["temperature"] * 0.1 # cache["temperature"] * 0.1 will causes a TypeError
````

## What changed
1. Correct the target temperature ("Set at") range for the TRVZB to 4–35 °C
2. Fix the TypeError that occurs when the TRVZB reports the current temperature.

##  Device data example
1. For reference, this is my TRVZB data from eWeLink cloud.
````json
{
    "itemType": 1,
    "itemData": {
        "name": "TRVZB",
        "deviceid": "a4000100b6",
        "apikey": "be1dc97c-a6df-4850-8b9b-c37ab59a7f1a",
        "extra": {
            "mac": "80462bfeffb8de947017",
            "apmac": "00:00:00:00:00:00",
            "model": "SN-MG22-TRVZB-01",
            "description": "Zigbee温控阀",
            "modelInfo": "6444e0eedfaa744da75f9791",
            "manufacturer": "深圳松诺技术有限公司",
            "brandId": "5c4c1aee3a7d24c7100be054",
            "uiid": 7017,
            "ui": "Zigbee温控阀_OTA",
            "reportProduct": "TRVZB",
            "staMac": "0x94deb8fffe2b4680"
        },
        "brandName": "SONOFF",
        "brandLogo": "https://cn-ota.coolkit.cc/logo/q62PevoglDNmwUJ9oPE7kRrpt1nL1CoA.png",
        "showBrand": true,
        "productModel": "TRVZB",
        "tags": {},
        "devConfig": {},
        "deviceConfigToApp": {
            "otaTimeout": 28800
        },
        "settings": {
            "opsNotify": 0,
            "opsHistory": 1,
            "alarmNotify": 1,
            "wxAlarmNotify": 0,
            "wxOpsNotify": 0,
            "wxDoorbellNotify": 0,
            "appDoorbellNotify": 1
        },
        "devGroups": [],
        "family": {
            "familyid": "68c4544a46e3e4dcee348e60",
            "index": -9,
            "members": [],
            "guests": []
        },
        "shareTo": [],
        "devicekey": "fc247f23-c5fd-46bf-a515-b007b02592c6",
        "online": true,
        "params": {
            "bindInfos": {
                "hiLink": [],
                "miot": [],
                "gaction": [
                    "be1dc97c-a6df-4850-8b9b-c37ab59a7f1a_ewelinkGoogleHome"
                ]
            },
            "parentid": "10025b5d5b",
            "subDevId": "80462bfeffb8de947017",
            "staMac": "0x94deb8fffe2b4680",
            "mon": "000000a0016800be021c00a003c000be052800a0052800a0",
            "tues": "000000a0016800be021c00a003c000be052800a0052800a0",
            "wed": "000000a0016800be021c00a003c000be052800a0052800a0",
            "thur": "000000a0016800be021c00a003c000be052800a0052800a0",
            "fri": "000000a0016800be021c00a003c000be052800a0052800a0",
            "sat": "000000a001a400be052800a0052800a0052800a0052800a0",
            "sun": "000000a001a400be052800a0052800a0052800a0052800a0",
            "isSupportBoost": true,
            "isSupportTimerMode": true,
            "isSupportDirection": true,
            "fwVersion": "1.4.1",
            "otaInfo": {
                "state": 0,
                "upgradeVersion": "1.4.1",
                "stateTime": 1769156501943,
                "reason": 0
            },
            "temperature": "269",
            "trigTime": 1769159900510,
            "tempCorrection": 4,
            "childLock": false,
            "windowSwitch": false,
            "ecoTargetTemp": 90,
            "temControlValue": -8,
            "openPercent": 51,
            "closePercent": 100,
            "workMode": "0",
            "timerTargetTemp": 0,
            "direction": "90",
            "curTargetTemp": 40,
            "workState": "0",
            "manTargetTemp": 40,
            "battery": 98,
            "temSouce": 0,
            "autoTargetTemp": 190
        },
        "denyFeatures": [
            "thermostatTemperatureCalibration",
            "value_open_ratio"
        ],
        "isSupportGroup": true,
        "isSupportedOnMP": false,
        "isSupportChannelSplit": false,
        "deviceFeature": {}
    },
    "index": -9
}
````
2. Device diagnostic data downloaded from HomeAssistant
````json
{
  "home_assistant": {
    "installation_type": "Unsupported Third Party Container",
    "version": "2026.1.0.dev0",
    "dev": true,
    "hassio": false,
    "virtualenv": true,
    "python_version": "3.13.11",
    "docker": true,
    "arch": "x86_64",
    "timezone": "Asia/Shanghai",
    "os_name": "Linux",
    "os_version": "6.17.0-8-generic",
    "run_as_root": false
  },
  "custom_components": {},
  "integration_manifest": {
    "domain": "sonoff",
    "name": "Sonoff",
    "codeowners": [
      "AlexxIT"
    ],
    "config_flow": true,
    "dependencies": [
      "http",
      "zeroconf"
    ],
    "documentation": "https://github.com/AlexxIT/SonoffLAN",
    "iot_class": "local_push",
    "issue_tracker": "https://github.com/AlexxIT/SonoffLAN/issues",
    "requirements": [
      "pycryptodome>=3.6.6"
    ],
    "version": "3.9.3",
    "is_built_in": true,
    "overwrites_built_in": false
  },
  "setup_times": {
    "null": {
      "setup": 0.00020768604008480906
    },
    "01KFAJN6WNQSA4G1V7EC5BN2F1": {
      "wait_import_platforms": -0.0007614450296387076,
      "wait_base_component": -0.0008612609817646444,
      "config_entry_setup": 1.5605076920473948
    }
  },
  "data": {
    "version": "fb36ad5",
    "cloud_auth": true,
    "config": null,
    "options": {},
    "errors": [],
    "device": {
      "uiid": 7017,
      "params": {
        "bindInfos": "***",
        "parentid": "10025b5d5b",
        "subDevId": "80462bfeffb8de947017",
        "staMac": "***",
        "temControlValue": -8,
        "tempCorrection": 4,
        "isSupportBoost": true,
        "isSupportTimerMode": true,
        "isSupportDirection": true,
        "fwVersion": "1.4.1",
        "otaInfo": {
          "state": 0,
          "upgradeVersion": "1.4.1",
          "stateTime": 1769722382868,
          "reason": 0
        },
        "childLock": false,
        "windowSwitch": false,
        "ecoTargetTemp": 90,
        "openPercent": 51,
        "closePercent": 100,
        "workMode": "0",
        "timerTargetTemp": 0,
        "direction": "90",
        "temperature": "262",
        "trigTime": 1769757961028,
        "curTargetTemp": 190,
        "workState": "0",
        "manTargetTemp": 190,
        "battery": 98,
        "temSouce": 0,
        "subDevRssi": -18
      },
      "model": "TRVZB",
      "online": true,
      "local": null,
      "localtype": null,
      "host": null,
      "deviceid": "a4000100b6"
    }
  },
  "issues": []
}
````