### PR TITLE
Allow Temperature Correction to be edited for TRVZB

### DIFF
--- a/custom_components/sonoff/core/devices.py
+++ b/custom_components/sonoff/core/devices.py
@@ -50,7 +50,7 @@ from ..light import (
     XZigbeeLight,
 )
 from ..media_player import XPanelBuzzer
-from ..number import XPulseWidth, XSensitivity
+from ..number import XPulseWidth, XSensitivity, XTempCorrectionNumber
 from ..remote import XRemote
 from ..select import XSelectStartup
 from ..sensor import (
@@ -609,12 +609,7 @@ DEVICES = {
             multiply=0.1,
             uid="eco_target_temperature",
         ),
-        spec(
-            XSensor,
-            param="tempCorrection",
-            multiply=0.1,
-            uid="temperature_correction",
-        ),
+        XTempCorrectionNumber,
         spec(XBoolSwitch, param="childLock", uid="child_lock"),
         spec(XBoolSwitch, param="windowSwitch", uid="window_switch"),
         spec(XHexVoltageTRVZB, param="runVoltage", uid="run_voltage"),

--- a/custom_components/sonoff/core/entity.py
+++ b/custom_components/sonoff/core/entity.py
@@ -16,6 +16,7 @@ ENTITY_CATEGORIES = {
     "pulseWidth": EntityCategory.CONFIG,
     "rssi": EntityCategory.DIAGNOSTIC,
     "sensitivity": EntityCategory.CONFIG,
+    "temperature_correction": EntityCategory.CONFIG,
 }
 
 ICONS = {

--- a/custom_components/sonoff/number.py
+++ b/custom_components/sonoff/number.py
@@ -1,4 +1,5 @@
-from homeassistant.components.number import NumberEntity
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.const import UnitOfTemperature
 
 from .core.const import DOMAIN
 from .core.entity import XEntity
@@ -57,6 +58,18 @@ class XPulseWidth(XNumber):
         await self.ewelink.send(
             self.device, {"pulse": "on", "pulseWidth": int(value / 0.5) * 500}
         )
+
+
+class XTempCorrectionNumber(XNumber):
+    param = "tempCorrection"
+    uid = "temperature_correction"
+    multiply = 0.1
+
+    _attr_native_min_value = -7
+    _attr_native_max_value = 7
+    _attr_native_step = 0.1
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _attr_mode = NumberMode.BOX
 
 
 class XSensitivity(XNumber):


### PR DESCRIPTION
Allows to automate the Temperature Correction parameter. 

Not sure if it is the best way, but theoretically this allows to link the TRVZB to an external sensor via modifying the Temperature Correction.