### PR TITLE
Fix 10 bugs and fix test suite for Python 3.12+

### DIFF
--- a/custom_components/sonoff/binary_sensor.py
+++ b/custom_components/sonoff/binary_sensor.py
@@ -146,7 +146,7 @@ class XRemoteSensor(BinarySensorEntity, RestoreEntity):
             and self.timeout
             and (ts := restore.attributes.get(ATTR_LAST_TRIGGERED))
         ):
-            left = self.timeout - (dt.utcnow() - dt.parse_datetime(ts)).seconds
+            left = self.timeout - int((dt.utcnow() - dt.parse_datetime(ts)).total_seconds())
             if left > 0:
                 self.task = asyncio.create_task(self.clear_state(left))
             else:

--- a/custom_components/sonoff/climate.py
+++ b/custom_components/sonoff/climate.py
@@ -168,6 +168,11 @@ class XClimateNS(XEntity, ClimateEntity):
     else:
         _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
 
+    def __init__(self, ewelink, device: dict):
+        # copy mutable list so each instance has its own hvac_modes
+        self._attr_hvac_modes = list(self._attr_hvac_modes)
+        super().__init__(ewelink, device)
+
     def set_state(self, params: dict):
         cache = self.device["params"]
         if cache != params:

--- a/custom_components/sonoff/core/ewelink/__init__.py
+++ b/custom_components/sonoff/core/ewelink/__init__.py
@@ -178,7 +178,7 @@ class XRegistry(XRegistryBase):
                 for old in device["params_bulk"]["configure"]:
                     # check on duplicates
                     if new["outlet"] == old["outlet"]:
-                        old["startup"] = new["switch"]
+                        old["startup"] = new["startup"]
                         break
                 else:
                     device["params_bulk"]["configure"].append(new)

--- a/custom_components/sonoff/core/ewelink/camera.py
+++ b/custom_components/sonoff/core/ewelink/camera.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import socket
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from threading import Thread
 from typing import Union
 
@@ -46,9 +46,9 @@ class Camera:
     init_data: bytes = None
 
     last_time: int = 0
-    sequence = 0
+    sequence: int = 0
 
-    wait_event = asyncio.Event()
+    wait_event: asyncio.Event = field(default_factory=asyncio.Event)
     wait_data: int = None
     wait_sequence: bytes = b"\x00\x00"
 
@@ -119,7 +119,11 @@ class XCameras(Thread):
 
         if device.wait_data == cmd:
             if cmd != 0xD1 or device.wait_sequence == data[8:10]:
-                device.wait_event.set()
+                try:
+                    loop = asyncio.get_event_loop()
+                    loop.call_soon_threadsafe(device.wait_event.set)
+                except RuntimeError:
+                    device.wait_event.set()
 
     def sendto(self, data: Union[bytes, str], device: Camera):
         if isinstance(data, str):

--- a/custom_components/sonoff/cover.py
+++ b/custom_components/sonoff/cover.py
@@ -177,7 +177,7 @@ class XCoverT5(XCover):
     _attr_is_closed = None  # unknown state
 
     def set_state(self, params: dict):
-        if "percentageControl" in params and params["calibState"] is True:
+        if "percentageControl" in params and params.get("calibState") is True:
             self._attr_current_cover_position = 100 - params["percentageControl"]
             self._attr_is_closed = self._attr_current_cover_position == 0
 

--- a/custom_components/sonoff/light.py
+++ b/custom_components/sonoff/light.py
@@ -361,7 +361,7 @@ class XLightL1(XLight):
 
         if "bright" in params:
             self._attr_brightness = conv(params["bright"], 1, 100, 1, 255)
-        if "colorR" in params and "colorG" in params and "colorB":
+        if "colorR" in params and "colorG" in params and "colorB" in params:
             self._attr_rgb_color = (
                 params["colorR"],
                 params["colorG"],
@@ -1180,7 +1180,7 @@ class XDiffuserLight(XOnOffLight):
         params = {}
 
         if effect is not None:
-            params["lightmode"] = mode = self.effect.index(effect) + 1
+            params["lightmode"] = mode = self._attr_effect_list.index(effect) + 1
             if mode == 2 and rgb_color is None:
                 rgb_color = self._attr_rgb_color
 

--- a/custom_components/sonoff/media_player.py
+++ b/custom_components/sonoff/media_player.py
@@ -82,7 +82,7 @@ class XPanelBuzzer(XEntity, MediaPlayerEntity):
         if media_source.is_media_source_id(media_id):
             media_id = media_id[len(media_source.URI_SCHEME) :]
 
-        extra = kwargs["extra"]
+        extra = kwargs.get("extra") or {}
         params = {
             "test": True,
             "fileName": media_id,

--- a/custom_components/sonoff/remote.py
+++ b/custom_components/sonoff/remote.py
@@ -101,7 +101,9 @@ class XRemote(XEntity, RemoteEntity):
             self.childs = childs
 
         except Exception as e:
-            _LOGGER.error(f"{self.unique_id} | can't setup RFBridge", exc_info=e)
+            _LOGGER.error(
+                f"{device['deviceid']} | can't setup RFBridge", exc_info=e
+            )
 
         # init bridge after childs for update available
         XEntity.__init__(self, ewelink, device)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,6 +10,18 @@ from custom_components.sonoff.core.ewelink import SIGNAL_ADD_ENTITIES, XRegistry
 
 DEVICEID = "1000123abc"
 
+# Create a shared event loop for all tests (Python 3.12+ no longer implicitly
+# creates one via asyncio.get_event_loop()).
+try:
+    _loop = asyncio.get_event_loop()
+except RuntimeError:
+    _loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(_loop)
+
+
+def get_loop() -> asyncio.AbstractEventLoop:
+    return _loop
+
 
 class DummyRegistry(XRegistry):
     def __init__(self):
@@ -21,7 +33,7 @@ class DummyRegistry(XRegistry):
         self.send_args = args
 
     def call(self, coro):
-        asyncio.get_event_loop().run_until_complete(coro)
+        get_loop().run_until_complete(coro)
         return self.send_args
 
 
@@ -36,7 +48,13 @@ def init(device: dict, config: dict = None) -> (XRegistry, List[XEntity]):
         params = device.setdefault("params", {})
         params.setdefault("staMac", "FF:FF:FF:FF:FF:FF")
 
-    asyncio.create_task = lambda _: None
+    def _mock_create_task(coro):
+        """Discard the coroutine without scheduling it, closing it to avoid
+        'coroutine was never awaited' RuntimeWarnings."""
+        coro.close()
+        return None
+
+    asyncio.create_task = _mock_create_task
     asyncio.get_running_loop = lambda: type("", (), {"_thread_id": threading.get_ident()})
 
     entities = []

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -65,7 +65,7 @@ from custom_components.sonoff.switch import (
     XToggle,
     XZigbeeSwitches,
 )
-from . import DEVICEID, DummyRegistry, init, save_to
+from . import DEVICEID, DummyRegistry, get_loop, init, save_to
 
 
 def get_entitites(device: Union[dict, list], config: dict = None) -> list:
@@ -73,7 +73,7 @@ def get_entitites(device: Union[dict, list], config: dict = None) -> list:
 
 
 def await_(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return get_loop().run_until_complete(coro)
 
 
 def test_simple_switch():

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -4,14 +4,14 @@ from custom_components.sonoff.core.devices import spec
 from custom_components.sonoff.core.ewelink import XDevice, XRegistry, XRegistryLocal
 from custom_components.sonoff.fan import XFan
 from custom_components.sonoff.light import XLightL1
-from . import save_to
+from . import get_loop, save_to
 
 
 def test_bulk():
     registry_send = []
 
     device = XDevice()
-    loop = asyncio.get_event_loop()
+    loop = get_loop()
     # noinspection PyTypeChecker
     registry: XRegistry = XRegistry(None)
     registry.send = save_to(registry_send)


### PR DESCRIPTION
# Changes — Bug Fixes & Test Improvements

## 1. `light.py` — Missing `in params` check for `colorB`

**File:** `custom_components/sonoff/light.py` (line 364)

**Issue:** The condition checked `"colorB"` (a non-empty string, always truthy) instead of `"colorB" in params`. This meant the color block executed whenever `colorR` and `colorG` were present, regardless of `colorB`, causing a `KeyError` when `colorB` was absent.

**Before:**
```python
if "colorR" in params and "colorG" in params and "colorB":
```

**After:**
```python
if "colorR" in params and "colorG" in params and "colorB" in params:
```

---

## 2. `light.py` — `.index()` called on string instead of list

**File:** `custom_components/sonoff/light.py` (line 1183)

**Issue:** `self.effect` holds the *current* effect string. Calling `.index(effect)` on a string searches character-by-character, not the list of valid effects. This silently produced wrong `lightmode` values or raised `ValueError`.

**Before:**
```python
params["lightmode"] = mode = self.effect.index(effect) + 1
```

**After:**
```python
params["lightmode"] = mode = self._attr_effect_list.index(effect) + 1
```

---

## 3. `core/ewelink/__init__.py` — Copy-paste error in `send_bulk`

**File:** `custom_components/sonoff/core/ewelink/__init__.py` (line 181)

**Issue:** When deduplicating bulk configure commands by outlet, the code updated `old["startup"]` with `new["switch"]` instead of `new["startup"]`. This meant the startup configuration was silently overwritten with the switch state.

**Before:**
```python
old["startup"] = new["switch"]
```

**After:**
```python
old["startup"] = new["startup"]
```

---

## 4. `climate.py` — Shared mutable `_attr_hvac_modes` list

**File:** `custom_components/sonoff/climate.py` (lines 171–175)

**Issue:** `_attr_hvac_modes` was defined as a class-level list. The `set_state` method conditionally appends modes (e.g. `HVACMode.FAN_ONLY`). Because all instances shared the same list, appending to one instance's modes affected every other instance of `XClimateNS`.

**Before:**
No `__init__` method; the class list was shared across all instances.

**After:**
```python
def __init__(self, ewelink, device: dict):
    # copy mutable list so each instance has its own hvac_modes
    self._attr_hvac_modes = list(self._attr_hvac_modes)
    super().__init__(ewelink, device)
```

---

## 5. `binary_sensor.py` — `.seconds` ignoring days component

**File:** `custom_components/sonoff/binary_sensor.py` (line 149)

**Issue:** `timedelta.seconds` only returns the seconds component (0–86399), ignoring the `days` field. For durations over 24 hours, the elapsed time calculation wrapped around. `total_seconds()` returns the full duration.

**Before:**
```python
left = self.timeout - (dt.utcnow() - dt.parse_datetime(ts)).seconds
```

**After:**
```python
left = self.timeout - int((dt.utcnow() - dt.parse_datetime(ts)).total_seconds())
```

---

## 6. `remote.py` — `self.unique_id` used before `__init__`

**File:** `custom_components/sonoff/remote.py` (line 104)

**Issue:** When child setup fails, the error log referenced `self.unique_id`. However, `XEntity.__init__` (which sets `unique_id`) runs *after* the child setup block. This caused an `AttributeError`, masking the real error.

**Before:**
```python
except Exception as e:
    _LOGGER.error(f"{self.unique_id} | can't setup RFBridge", exc_info=e)
```

**After:**
```python
except Exception as e:
    _LOGGER.error(
        f"{device['deviceid']} | can't setup RFBridge", exc_info=e
    )
```

---

## 7. `media_player.py` — `KeyError` on missing `extra` kwarg

**File:** `custom_components/sonoff/media_player.py` (line 85)

**Issue:** `kwargs["extra"]` raises `KeyError` when `play_media` is called without the `extra` keyword argument. Using `.get()` with a fallback avoids the crash.

**Before:**
```python
extra = kwargs["extra"]
```

**After:**
```python
extra = kwargs.get("extra") or {}
```

---

## 8. `core/ewelink/camera.py` — Shared `asyncio.Event` across all Camera instances

**File:** `custom_components/sonoff/core/ewelink/camera.py` (lines 49–52)

**Issue:** `wait_event = asyncio.Event()` as a bare class variable meant every `Camera` dataclass instance shared the *same* `Event` object. Setting it on one camera unblocked all cameras waiting.

**Before:**
```python
wait_event = asyncio.Event()
```

**After:**
```python
wait_event: asyncio.Event = field(default_factory=asyncio.Event)
```

Also added `field` to the import:
```python
from dataclasses import dataclass, field
```

---

## 9. `core/ewelink/camera.py` — Thread-unsafe `Event.set()` call

**File:** `custom_components/sonoff/core/ewelink/camera.py` (lines 122–126)

**Issue:** `datagram_received` runs inside a background `Thread`, but `asyncio.Event.set()` is not thread-safe. Calling it from a non-event-loop thread can cause missed wake-ups or corruption. `loop.call_soon_threadsafe()` schedules the call safely on the event loop.

**Before:**
```python
device.wait_event.set()
```

**After:**
```python
try:
    loop = asyncio.get_event_loop()
    loop.call_soon_threadsafe(device.wait_event.set)
except RuntimeError:
    device.wait_event.set()
```

---

## 10. `cover.py` — `KeyError` when `calibState` is absent

**File:** `custom_components/sonoff/cover.py` (line 180)

**Issue:** `params["calibState"]` raises `KeyError` when the device sends a `percentageControl` update without a `calibState` key. Using `.get()` returns `None` when the key is absent, and the `is True` check still works correctly.

**Before:**
```python
if "percentageControl" in params and params["calibState"] is True:
```

**After:**
```python
if "percentageControl" in params and params.get("calibState") is True:
```

---

## Test Fixes

### 11. `tests/__init__.py` — Event loop creation for Python 3.12+

**Issue:** Python 3.12+ raises `RuntimeError` from `asyncio.get_event_loop()` when no current event loop exists. All tests relying on this call failed immediately.

**Fix:** Added a shared `get_loop()` helper that creates and caches a single event loop:

```python
try:
    _loop = asyncio.get_event_loop()
except RuntimeError:
    _loop = asyncio.new_event_loop()
    asyncio.set_event_loop(_loop)

def get_loop() -> asyncio.AbstractEventLoop:
    return _loop
```

### 12. `tests/__init__.py` — `asyncio.create_task` mock leaking coroutines

**Issue:** `asyncio.create_task = lambda _: None` discarded coroutines without closing them, producing `RuntimeWarning: coroutine was never awaited` for every entity setup.

**Before:**
```python
asyncio.create_task = lambda _: None
```

**After:**
```python
def _mock_create_task(coro):
    """Discard the coroutine without scheduling it, closing it to avoid
    'coroutine was never awaited' RuntimeWarnings."""
    coro.close()
    return None

asyncio.create_task = _mock_create_task
```

### 13. `tests/test_entity.py` & `tests/test_misc.py` — `get_loop()` adoption

**Issue:** Both files called `asyncio.get_event_loop()` directly, which fails on Python 3.12+.

**Fix:** Replaced with `get_loop()` imported from `tests`:
```python
from . import DEVICEID, DummyRegistry, get_loop, init, save_to
```

---

## Test Results

After all fixes: **70 passed, 0 failed, 1 warning** (upstream HA deprecation only).
