### PR TITLE
Add power-on state support for S60TPF (UIID 190)

### DIFF
--- a/custom_components/sonoff/core/devices.py
+++ b/custom_components/sonoff/core/devices.py
@@ -426,6 +426,7 @@ DEVICES = {
     # S60TPF, https://github.com/AlexxIT/SonoffLAN/issues/1514
     190: [
         XSwitchPOWR3,
+        Startup1,
         LED,
         RSSI,
         spec(XSensor100, param="current"),

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -47,6 +47,7 @@ from custom_components.sonoff.light import (
     XT5Light,
 )
 from custom_components.sonoff.number import XNumber, XPulseWidth
+from custom_components.sonoff.select import XSelectStartup
 from custom_components.sonoff.sensor import (
     XEnergySensorDualR3,
     XEnergyTotal,
@@ -1716,6 +1717,10 @@ def test_powr3():
         "operSide": 1,
     }
     entities = get_entitites({"extra": {"uiid": 190}, "params": params})
+
+    startup: XSelectStartup = next(e for e in entities if e.uid == "1" and isinstance(e, XSelectStartup))
+    assert startup._attr_current_option == "off"
+    assert startup._attr_options == ["off", "on", "stay"]
 
     energy: XEnergyTotal = next(e for e in entities if e.uid == "energy_day")
     assert energy.device_class == SensorDeviceClass.ENERGY


### PR DESCRIPTION
Add `Startup1` (XSelectStartup) to UIID 190 device spec, enabling the
power-on state select entity (off/on/stay) for the S60TPF smart plug.

The device already reports `configure: [{startup, outlet}]` in its params,
which is the same format used by DualR3, MINIR3/4, and TX Ultimate devices
that already have startup support.

Relates to #1618, #1585

Tested with S60TPF on SonoffLAN v3.9.3 / HA 2026.2.3.