### PR TITLE
Fix missing 'in params' check for colorB in light.py

### DIFF
--- a/custom_components/sonoff/light.py
+++ b/custom_components/sonoff/light.py
@@ -361,7 +361,7 @@ class XLightL1(XLight):
 
         if "bright" in params:
             self._attr_brightness = conv(params["bright"], 1, 100, 1, 255)
-        if "colorR" in params and "colorG" in params and "colorB":
+        if "colorR" in params and "colorG" in params and "colorB" in params:
             self._attr_rgb_color = (
                 params["colorR"],
                 params["colorG"],


### PR DESCRIPTION
**File:** `custom_components/sonoff/light.py` (line 364)

**Issue:** The condition checked `"colorB"` (a non-empty string, always truthy) instead of `"colorB" in params`. This meant the color block executed whenever `colorR` and `colorG` were present, regardless of `colorB`, causing a `KeyError` when `colorB` was absent.

**Before:**
```python
if "colorR" in params and "colorG" in params and "colorB":
```

**After:**
```python
if "colorR" in params and "colorG" in params and "colorB" in params:
```