### PR TITLE
Fix .index() called on string instead of list in light.py

### DIFF
--- a/custom_components/sonoff/light.py
+++ b/custom_components/sonoff/light.py
@@ -1180,7 +1180,7 @@ class XDiffuserLight(XOnOffLight):
         params = {}
 
         if effect is not None:
-            params["lightmode"] = mode = self.effect.index(effect) + 1
+            params["lightmode"] = mode = self._attr_effect_list.index(effect) + 1
             if mode == 2 and rgb_color is None:
                 rgb_color = self._attr_rgb_color
 


### PR DESCRIPTION
**File:** `custom_components/sonoff/light.py` (line 1183)

**Issue:** `self.effect` holds the current effect string. Calling `.index(effect)` on a string searches character-by-character, not the list of valid effects. This silently produced wrong `lightmode` values or raised `ValueError`.

**Before:**
```python
params["lightmode"] = mode = self.effect.index(effect) + 1
```

**After:**
```python
params["lightmode"] = mode = self._attr_effect_list.index(effect) + 1
```