### PR TITLE
Fix copy-paste error in send_bulk: startup overwritten with switch value

### DIFF
--- a/custom_components/sonoff/core/ewelink/__init__.py
+++ b/custom_components/sonoff/core/ewelink/__init__.py
@@ -178,7 +178,7 @@ class XRegistry(XRegistryBase):
                 for old in device["params_bulk"]["configure"]:
                     # check on duplicates
                     if new["outlet"] == old["outlet"]:
-                        old["startup"] = new["switch"]
+                        old["startup"] = new["startup"]
                         break
                 else:
                     device["params_bulk"]["configure"].append(new)


### PR DESCRIPTION
**File:** `custom_components/sonoff/core/ewelink/__init__.py` (line 181)

**Issue:** When deduplicating bulk configure commands by outlet, the code updated `old["startup"]` with `new["switch"]` instead of `new["startup"]`. This meant the startup configuration was silently overwritten with the switch state.

**Before:**
```python
old["startup"] = new["switch"]
```

**After:**
```python
old["startup"] = new["startup"]
```