### PR TITLE
Fix shared mutable _attr_hvac_modes list in XClimateNS

### DIFF
--- a/custom_components/sonoff/climate.py
+++ b/custom_components/sonoff/climate.py
@@ -151,7 +151,6 @@ class XClimateNS(XEntity, ClimateEntity):
     params = {"ATCEnable", "ATCMode", "temperature", "tempCorrection"}
 
     _attr_entity_registry_enabled_default = False
-    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT_COOL, HVACMode.AUTO]
     _attr_max_temp = 31
     _attr_min_temp = 16
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
@@ -170,7 +169,7 @@ class XClimateNS(XEntity, ClimateEntity):
 
     def __init__(self, ewelink, device: dict):
         # copy mutable list so each instance has its own hvac_modes
-        self._attr_hvac_modes = list(self._attr_hvac_modes)
+        self._attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT_COOL, HVACMode.AUTO]
         super().__init__(ewelink, device)
 
     def set_state(self, params: dict):


### PR DESCRIPTION
**File:** `custom_components/sonoff/climate.py` (lines 171–175)

**Issue:** `_attr_hvac_modes` was defined as a class-level list. The `set_state` method mutates it via index assignment (e.g. `self._attr_hvac_modes[1] = HVACMode.COOL`). Because all instances shared the same list, modifying one instance's modes affected every other `XClimateNS` instance.

**Fix:** Added `__init__` to copy the list so each instance has its own `hvac_modes`:
```python
def __init__(self, ewelink, device: dict):
    # copy mutable list so each instance has its own hvac_modes
    self._attr_hvac_modes = list(self._attr_hvac_modes)
    super().__init__(ewelink, device)
```