### PR TITLE
Fix KeyError when calibState is absent in cover.py

### DIFF
--- a/custom_components/sonoff/cover.py
+++ b/custom_components/sonoff/cover.py
@@ -177,7 +177,7 @@ class XCoverT5(XCover):
     _attr_is_closed = None  # unknown state
 
     def set_state(self, params: dict):
-        if "percentageControl" in params and params["calibState"] is True:
+        if "percentageControl" in params and params.get("calibState") is True:
             self._attr_current_cover_position = 100 - params["percentageControl"]
             self._attr_is_closed = self._attr_current_cover_position == 0
 


### PR DESCRIPTION
**File:** `custom_components/sonoff/cover.py` (line 180)

**Issue:** `params["calibState"]` raises `KeyError` when the device sends a `percentageControl` update without a `calibState` key. Using `.get()` returns `None` when the key is absent, and the `is True` check still works correctly.

**Before:**
```python
if "percentageControl" in params and params["calibState"] is True:
```

**After:**
```python
if "percentageControl" in params and params.get("calibState") is True:
```