### PR TITLE
Fix MINI-DIM not turning on when setting brightness

### DIFF
--- a/custom_components/sonoff/light.py
+++ b/custom_components/sonoff/light.py
@@ -1264,8 +1264,10 @@ class XMiniDim(XEntity, LightEntity):
 
     async def async_turn_on(self, brightness: int = None, **kwargs) -> None:
         if brightness is not None:
-            value = conv(brightness, 1, 255, 1, 100)
-            await self.ewelink.send(self.device, {"brightness": value})
+            await self.ewelink.send(
+                self.device,
+                {"brightness": conv(brightness, 1, 255, 1, 100), "switch": "on"},
+            )
         else:
             await self.ewelink.send(self.device, {"switch": "on"})
 

--- a/custom_components/sonoff/light.py
+++ b/custom_components/sonoff/light.py
@@ -1264,12 +1264,10 @@ class XMiniDim(XEntity, LightEntity):
 
     async def async_turn_on(self, brightness: int = None, **kwargs) -> None:
         if brightness is not None:
-            await self.ewelink.send(
-                self.device,
-                {"brightness": conv(brightness, 1, 255, 1, 100), "switch": "on"},
-            )
+            params = {"brightness": conv(brightness, 1, 255, 1, 100), "switch": "on"}
         else:
-            await self.ewelink.send(self.device, {"switch": "on"})
+            params = {"switch": "on"}
+        await self.ewelink.send(self.device, params)
 
     async def async_turn_off(self, **kwargs) -> None:
         await self.ewelink.send(self.device, {"switch": "off"})


### PR DESCRIPTION
Hey, I've got a MINI-DIM (uiid 277) and noticed that when I set brightness through HA (or Google Home), the light doesn't actually turn on - it just updates the brightness value while staying off. You have to toggle it on separately first.

The issue is in `XMiniDim.async_turn_on` - when brightness is provided, only the `brightness` param gets sent without `switch: on`. The device needs both to turn on at the desired level.

The fix sends `switch` and `brightness` together in a single command so the light turns on at the requested brightness straight away. When no brightness is specified it still just sends `switch: on` like before.

Only affects `XMiniDim` (MINI-DIM / uiid 277), no other device classes touched.