### PR TITLE
Add transition support for Sonoff MINI-DIM

### DIFF
--- a/custom_components/sonoff/light.py
+++ b/custom_components/sonoff/light.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 
 from homeassistant.components.light import (
@@ -1254,6 +1255,7 @@ class XMiniDim(XEntity, LightEntity):
 
     _attr_color_mode = ColorMode.BRIGHTNESS
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+    _attr_supported_features = LightEntityFeature.TRANSITION
 
     def set_state(self, params: dict):
         if "switch" in params:
@@ -1262,12 +1264,23 @@ class XMiniDim(XEntity, LightEntity):
         if "brightness" in params:
             self._attr_brightness = conv(params["brightness"], 1, 100, 1, 255)
 
-    async def async_turn_on(self, brightness: int = None, **kwargs) -> None:
+    async def async_turn_on(self, brightness: int = None, transition: float = None, **kwargs) -> None:
         if brightness is not None:
             params = {"brightness": conv(brightness, 1, 255, 1, 100), "switch": "on"}
         else:
             params = {"switch": "on"}
+
         await self.ewelink.send(self.device, params)
+
+        if transition is not None:
+            # The MINI-DIM firmware supports transitionTime (in ms) for smooth
+            # hardware fading, but only through the cloud API — the local
+            # /zeroconf endpoint ignores it and times out. So we send the
+            # brightness via local first (fast), then fire the transition
+            # command through cloud in the background.
+            cloud_params = dict(params)
+            cloud_params["transitionTime"] = int(transition * 1000)
+            asyncio.create_task(self.ewelink.cloud.send(self.device, cloud_params))
 
     async def async_turn_off(self, **kwargs) -> None:
         await self.ewelink.send(self.device, {"switch": "off"})

--- a/custom_components/sonoff/light.py
+++ b/custom_components/sonoff/light.py
@@ -1,4 +1,3 @@
-import asyncio
 import time
 
 from homeassistant.components.light import (
@@ -1264,23 +1263,24 @@ class XMiniDim(XEntity, LightEntity):
         if "brightness" in params:
             self._attr_brightness = conv(params["brightness"], 1, 100, 1, 255)
 
-    async def async_turn_on(self, brightness: int = None, transition: float = None, **kwargs) -> None:
+    async def async_turn_on(
+        self, brightness: int = None, transition: float = None, **kwargs
+    ) -> None:
+        params = {"switch": "on"}
+
         if brightness is not None:
-            params = {"brightness": conv(brightness, 1, 255, 1, 100), "switch": "on"}
-        else:
-            params = {"switch": "on"}
+            params["brightness"] = conv(brightness, 1, 255, 1, 100)
 
-        await self.ewelink.send(self.device, params)
-
-        if transition is not None:
+        if transition is not None and self.ewelink.can_cloud(self.device):
             # The MINI-DIM firmware supports transitionTime (in ms) for smooth
             # hardware fading, but only through the cloud API — the local
             # /zeroconf endpoint ignores it and times out. So we send the
             # brightness via local first (fast), then fire the transition
             # command through cloud in the background.
-            cloud_params = dict(params)
-            cloud_params["transitionTime"] = int(transition * 1000)
-            asyncio.create_task(self.ewelink.cloud.send(self.device, cloud_params))
+            params["transitionTime"] = int(transition * 1000)
+            await self.ewelink.cloud.send(self.device, params)
+        else:
+            await self.ewelink.send(self.device, params)
 
     async def async_turn_off(self, **kwargs) -> None:
         await self.ewelink.send(self.device, {"switch": "off"})


### PR DESCRIPTION
Hey! I've been using the MINI-DIM (UIID 277) with an adaptive lighting automation and noticed it was the only dimmer class without transition support. Thought I'd have a go at adding it.

## What I found

The MINI-DIM firmware (tested on 1.1.2) supports a `transitionTime` parameter in milliseconds — the device does smooth hardware fading when it receives it alongside a brightness command. The catch is it only works through the cloud API. The local `/zeroconf` endpoint either ignores it or returns a `text/html` error and times out.

## What this does

- Adds `LightEntityFeature.TRANSITION` to `XMiniDim`
- When `transition` is passed to `light.turn_on`, the brightness is sent via local as usual (fast), then the full command including `transitionTime` is fired through cloud in the background using `asyncio.create_task` so the caller isn't blocked
- When no transition is requested, behaviour is exactly the same as before

## Testing

Tested on my MINI-DIM (firmware 1.1.2) with:
- Manual `light.turn_on` calls with `transition: 3` and `transition: 5` — smooth fades both up and down
- HA scenes with transitions
- Automation loops (works but cloud latency means transitions arrive slightly after the local command)
- No transition (existing behaviour) — unchanged

Happy to adjust if there's a better way to handle the local/cloud split. Cheers!