### PR TITLE
Fix RFBridge button overrides being coerced into binary sensors

### DIFF
--- a/custom_components/sonoff/__init__.py
+++ b/custom_components/sonoff/__init__.py
@@ -75,7 +75,7 @@ CONFIG_SCHEMA = vol.Schema(
                         {
                             vol.Optional(CONF_NAME): cv.string,
                             vol.Optional(CONF_DEVICE_CLASS): cv.string,
-                            vol.Optional(CONF_TIMEOUT, default=120): cv.positive_int,
+                            vol.Optional(CONF_TIMEOUT): cv.positive_int,
                             vol.Optional(CONF_PAYLOAD_OFF): cv.string,
                         },
                         extra=vol.ALLOW_EXTRA,

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
-from custom_components.sonoff import remote
+from custom_components.sonoff import CONFIG_SCHEMA, remote
 from custom_components.sonoff.binary_sensor import XBinarySensor, XRemoteSensor
 from custom_components.sonoff.climate import XClimateNS, XThermostat
 from custom_components.sonoff.core import devices
@@ -630,6 +630,46 @@ def test_rfbridge():
         },
     )
     assert alarm.state == "off"
+
+
+def test_rfbridge_button_override_without_timeout():
+    config = CONFIG_SCHEMA(
+        {"sonoff": {"rfbridge": {"Button A": {"device_class": "button"}}}}
+    )
+    assert config["sonoff"]["rfbridge"]["Button A"] == {"device_class": "button"}
+
+    entities = get_entitites(
+        {
+            "extra": {"uiid": 28},
+            "params": {
+                "cmd": "trigger",
+                "fwVersion": "3.4.0",
+                "init": 1,
+                "rfChl": 0,
+                "rfList": [{"rfChl": 0, "rfVal": "xxx"}],
+                "rfTrig0": "2020-05-10T19:29:43.000Z",
+                "rssi": -55,
+                "setState": "arm",
+                "sledOnline": "on",
+                "timers": [],
+                "version": 8,
+            },
+            "tags": {
+                "disable_timers": [],
+                "zyx_info": [
+                    {
+                        "buttonName": [{"0": "Button1"}],
+                        "name": "Button A",
+                        "remote_type": "6",
+                    }
+                ],
+            },
+        },
+        config["sonoff"],
+    )
+
+    button = next(e for e in entities if e.__class__.__name__ == "XRemoteButton")
+    assert button.name == "Button A"
 
 
 def test_wifi_sensor():

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
 from custom_components.sonoff import CONFIG_SCHEMA, remote
 from custom_components.sonoff.binary_sensor import XBinarySensor, XRemoteSensor
+from custom_components.sonoff.button import XRemoteButton
 from custom_components.sonoff.climate import XClimateNS, XThermostat
 from custom_components.sonoff.core import devices
 from custom_components.sonoff.core.devices import Battery
@@ -668,7 +669,7 @@ def test_rfbridge_button_override_without_timeout():
         config["sonoff"],
     )
 
-    button = next(e for e in entities if e.__class__.__name__ == "XRemoteButton")
+    button = next(e for e in entities if isinstance(e, XRemoteButton))
     assert button.name == "Button A"
 
 


### PR DESCRIPTION
RFBridge per-button YAML overrides support setting device_class: button so learned RF codes can be exposed as Home Assistant button entities instead of sticky binary_sensor entities. In practice this override did not work for remote_type 6 entries (the RFBridge channels that eWeLink reports as alarm-style remotes), even when the YAML was loaded correctly and the entity names matched. The integration kept recreating those entities as binary sensors.

I've found it when I added this to `configuration.yaml` but nothing changed, my buttons were still exposed as binary sensors:

```
sonoff: 
  rfbridge:
    Button A:
      device_class: button
```

The root cause was in config validation rather than in the RFBridge runtime mapping itself. The rfbridge schema assigned a default timeout of 120 seconds to every configured child entry, including entries that only specified device_class: button. Later, the RFBridge entity builder treats any child that has a timeout or payload_off as sensor-like and removes the button classification. As a result, a user-provided device_class: button override was silently converted back into the binary-sensor code path before entities were created.

Fix this by removing the schema-level default for rfbridge timeout. Timeout remains optional in YAML, and the runtime code continues to apply its existing default timeout only for actual XRemoteSensor entities. This preserves the intended behavior for sensor/alarm configurations while allowing device_class: button overrides to survive schema parsing and be honored for RFBridge children.

Also add a regression test that validates a minimal rfbridge override with device_class: button does not gain an implicit timeout during schema validation and produces an XRemoteButton for a remote_type 6 RFBridge child. This protects the exact user-facing scenario where changing the entity type in YAML previously had no effect.