### PR TITLE
fix: add type check for device_class in cover.py to prevent unhashable type error

### DIFF
--- a/custom_components/sonoff/cover.py
+++ b/custom_components/sonoff/cover.py
@@ -25,7 +25,7 @@ class XCover(XEntity, CoverEntity):
 
     def __init__(self, ewelink: XRegistry, device: dict):
         XEntity.__init__(self, ewelink, device)
-        self._attr_device_class = DEVICE_CLASSES.get(device.get("device_class"))
+        self._attr_device_class = DEVICE_CLASSES.get(device.get("device_class")) if isinstance(device.get("device_class"), str) else None
 
     def set_state(self, params: dict):
         # => command to cover from mobile app

--- a/custom_components/sonoff/cover.py
+++ b/custom_components/sonoff/cover.py
@@ -25,7 +25,10 @@ class XCover(XEntity, CoverEntity):
 
     def __init__(self, ewelink: XRegistry, device: dict):
         XEntity.__init__(self, ewelink, device)
-        self._attr_device_class = DEVICE_CLASSES.get(device.get("device_class")) if isinstance(device.get("device_class"), str) else None
+        # Fix device_class for multi-channel device UIID 211
+        # https://github.com/AlexxIT/SonoffLAN/pull/1785
+        if (v := device.get("device_class")) and isinstance(v, str):
+            self._attr_device_class = DEVICE_CLASSES.get(v)
 
     def set_state(self, params: dict):
         # => command to cover from mobile app


### PR DESCRIPTION
### Description of the problem

Currently, the `device_class` YAML configuration key serves a dual purpose in this integration:
1. Defining the type of cover entity (e.g., `"curtain"`, `"blind"`) using a string.
2. Defining relay channel mappings for multi-gang switches (e.g., `[light, switch, switch]`) using a list or dict.

For complex devices that support *both* multi-channel relays and an internal electromotor/cover entity (such as the Sonoff TX Ultimate T5 3-gang switch, UIID `0211`), this variable overloading causes a fatal crash. 

When a user defines a list for channel mapping, `cover.py` inadvertently intercepts this list at initialization. On line 28, it attempts to use the list as a dictionary key for `DEVICE_CLASSES.get()`, resulting in:

`TypeError: cannot use 'list' as a dict key (unhashable type: 'list')`

This instantly aborts the setup process, and the entire device fails to load.

### Description of the fix

Added a simple `isinstance()` type-check on line 28 of `custom_components/sonoff/cover.py`. 

The dictionary lookup will now only execute if the `device_class` provided is actually a string. If a list or dict is passed (for channel mapping), it gracefully falls back to `None`, bypassing the exception entirely. 

### Impact

* Resolves the crash for multi-gang switches that also expose cover entities. (T5 3-gang, was not initializing if you set the entities types e.g. "[light, switch, light]")
* The device loads successfully and correctly applies the list mapping to its relays.
* Standard cover setups (where `device_class` is a string like `"blind"`) remain completely unaffected.
