### PR TITLE
fix: XLightB1 (UIID22) crashes on partial cloud updates and None brightness/color_temp

### DIFF
--- a/custom_components/sonoff/light.py
+++ b/custom_components/sonoff/light.py
@@ -262,29 +262,31 @@ class XLightB1(XLight):
                 self._attr_effect = None
 
         if self.color_mode == ColorMode.COLOR_TEMP:
-            # from 25 to 255
-            cold = int(params["channel0"])
-            warm = int(params["channel1"])
-            if warm == 0:
-                self._attr_color_temp_kelvin = 6500
-            elif cold == warm:
-                self._attr_color_temp_kelvin = 4250
-            elif cold == 0:
-                self._attr_color_temp_kelvin = 2000
-            self._attr_brightness = conv(max(cold, warm), 25, 255, 1, 255)
+            if "channel0" in params and "channel1" in params:
+                # from 25 to 255
+                cold = int(params["channel0"])
+                warm = int(params["channel1"])
+                if warm == 0:
+                    self._attr_color_temp_kelvin = 6500
+                elif cold == warm:
+                    self._attr_color_temp_kelvin = 4250
+                elif cold == 0:
+                    self._attr_color_temp_kelvin = 2000
+                self._attr_brightness = conv(max(cold, warm), 25, 255, 1, 255)
 
         else:
-            self._attr_rgb_color = (
-                int(params["channel2"]),
-                int(params["channel3"]),
-                int(params["channel4"]),
-            )
+            if "channel2" in params and "channel3" in params and "channel4" in params:
+                self._attr_rgb_color = (
+                    int(params["channel2"]),
+                    int(params["channel3"]),
+                    int(params["channel4"]),
+                )
 
     def get_params(self, brightness, color_temp_kelvin, rgb_color, effect) -> dict:
         if brightness or color_temp_kelvin:
-            ch = str(conv(brightness or self.brightness, 1, 255, 25, 255))
+            ch = str(conv(brightness or self.brightness or 255, 1, 255, 25, 255))
             if not color_temp_kelvin:
-                color_temp_kelvin = self.color_temp_kelvin
+                color_temp_kelvin = self.color_temp_kelvin or 4250
             if color_temp_kelvin >= 5000:
                 params = {"channel0": ch, "channel1": "0"}
             elif color_temp_kelvin >= 3500:


### PR DESCRIPTION
Fixes #1791

## Summary

Three crashes in `XLightB1` (`light.py`, UIID22 / Sonoff B1) — partial cloud updates and uninitialized state on first call.

## Changes

**Bug 1 — KeyError on partial cloud update**

Cloud sends partial parameter updates (only changed keys). `set_state` read channel keys unconditionally — crashes when absent.

Before:
```python
if self.color_mode == ColorMode.COLOR_TEMP:
    cold = int(params["channel0"])  # KeyError if absent
    warm = int(params["channel1"])
else:
    self._attr_rgb_color = (
        int(params["channel2"]),    # KeyError if absent
        ...
    )
```
After:
```python
if self.color_mode == ColorMode.COLOR_TEMP:
    if "channel0" in params and "channel1" in params:
        cold = int(params["channel0"])
        ...
else:
    if "channel2" in params and "channel3" in params and "channel4" in params:
        self._attr_rgb_color = (...)
```

**Bug 2 — TypeError when brightness is None**

Before:
```python
ch = str(conv(brightness or self.brightness, 1, 255, 25, 255))
```
After:
```python
ch = str(conv(brightness or self.brightness or 255, 1, 255, 25, 255))
```

**Bug 3 — TypeError when color_temp_kelvin is None**

Before:
```python
color_temp_kelvin = self.color_temp_kelvin
if color_temp_kelvin >= 5000:  # TypeError: None >= 5000
```
After:
```python
color_temp_kelvin = self.color_temp_kelvin or 4250  # midpoint default
```

## Tests

3 new tests added after `test_light_22`:

| Test | Verifies |
|------|----------|
| `test_light_22_partial_update_color_temp_mode` | RGB-only cloud update while in COLOR_TEMP mode — no KeyError, attrs preserved |
| `test_light_22_partial_update_rgb_mode` | channel0/1 only update while in RGB mode — no KeyError, rgb_color preserved |
| `test_light_22_turn_on_no_prior_state` | async_turn_on with brightness=None and color_temp_kelvin=None — covers Bugs 2 and 3 |

## Evidence

From diagnostics on affected HA instance:
- KeyError: 'channel2' — 4 occurrences
- TypeError: unsupported operand type(s) for -: 'NoneType' and 'int' — 5 occurrences
- TypeError: '>=' not supported between instances of 'NoneType' and 'int' — 3 occurrences

## Environment
- Home Assistant OS: 17.3 / Core: 2026.5.1
- SonoffLAN: v3.11.1
- Device: Sonoff B1 (UIID22)
- Tested: on/off, brightness, color temp, RGB — no errors post-fix