### PR TITLE
1786 snzb 01m orb support

### DIFF
--- a/custom_components/sonoff/core/devices.py
+++ b/custom_components/sonoff/core/devices.py
@@ -69,6 +69,7 @@ from ..sensor import (
     XHexVoltageTRVZB,
     XHumCorrection,
     XHumidityTH,
+    XOrb,
     XOutdoorTempNS,
     XSensor,
     XT5Action,
@@ -743,6 +744,9 @@ DEVICES = {
             XSensor, param="remoteTemperature", uid="remote_temperature", multiply=0.01
         ),
     ],
+    # SNZB-01M Orb (4-button multi-action remote)
+    # https://github.com/AlexxIT/SonoffLAN/issues/1786
+    7039: [XOrb, Battery, ZRSSI],
 }
 
 

--- a/custom_components/sonoff/sensor.py
+++ b/custom_components/sonoff/sensor.py
@@ -372,6 +372,7 @@ class XWiFiDoorBattery(XSensor):
 
 
 BUTTON_STATES = ["single", "double", "hold"]
+ORB_BUTTON_STATES = ["single", "double", "long", "triple"]
 
 
 class XEventSesor(XEntity, SensorEntity):
@@ -448,6 +449,34 @@ class XButtonLocalKey(XButtonBase):
         # MINI-2GS https://github.com/AlexxIT/SonoffLAN/issues/1694
         # MINI-ZB2GS-L https://github.com/AlexxIT/SonoffLAN/issues/1701
         XButtonBase.set_state(self, params["localKeyPass"])
+
+
+class XOrb(XButtonBase):
+    """SNZB-01M Orb button entity - supports 4 buttons with 4 actions each.
+    State format: {action}_button_{number}
+    """
+    params = {"key"}
+
+    def __init__(self, ewelink: XRegistry, device: dict):
+        # remember initial trigTime so stale replays after reconnect are skipped
+        params = device["params"]
+        self.last_trig_time = params.get("trigTime") or params.get("actionTime")
+        super().__init__(ewelink, device)
+
+    def set_state(self, params: dict):
+        # skip stale events replayed after device reconnect
+        if trig_time := (params.get("trigTime") or params.get("actionTime")):
+            if trig_time == self.last_trig_time:
+                return
+            self.last_trig_time = trig_time
+
+        button = params.get("outlet")
+        key = ORB_BUTTON_STATES[params["key"]]
+        # New format: action_button_number
+        self._attr_native_value = (
+            f"{key}_button_{button + 1}" if button is not None else key
+        )
+        asyncio.create_task(self.clear_state())
 
 
 class XT5Action(XEventSesor):

--- a/custom_components/sonoff/sensor.py
+++ b/custom_components/sonoff/sensor.py
@@ -371,7 +371,7 @@ class XWiFiDoorBattery(XSensor):
         return self.ewelink.cloud.online
 
 
-BUTTON_STATES = ["single", "double", "hold"]
+BUTTON_STATES = ["single", "double", "long", "triple"]
 
 
 class XEventSesor(XEntity, SensorEntity):
@@ -390,7 +390,7 @@ class XButtonBase(XEventSesor):
         button = params.get("outlet")
         key = BUTTON_STATES[params["key"]]
         self._attr_native_value = (
-            f"button_{button + 1}_{key}" if button is not None else key
+            f"{key}_button_{button + 1}" if button is not None else key
         )
         asyncio.create_task(self.clear_state())
 
@@ -421,6 +421,9 @@ class XButtonLocalKey(XButtonBase):
     def __init__(self, ewelink: XRegistry, device: dict):
         super().__init__(ewelink, device)
         self.last_seq = None
+        # remember initial trigTime/actionTime so stale replays after reconnect are skipped
+        params = device["params"]
+        self.last_trig_time = params.get("trigTime") or params.get("actionTime")
 
     def set_state(self, params: dict):
         if seq := self.device.get("local_seq"):
@@ -432,9 +435,21 @@ class XButtonLocalKey(XButtonBase):
         if self._attr_native_value:
             return
 
+        # Extract params from nested localKeyPass or top-level format
+        button_params = None
+
         # cloud click: {'localKeyPass': {'outlet': 0, 'key': 0}}
         if len(params) == 1:
-            pass
+            button_params = params.get("localKeyPass")
+        # cloud click (new format): {'key': 0, 'outlet': 0, 'actionTime': '...'}
+        elif "key" in params and ("outlet" in params or "actionTime" in params):
+            # skip stale events replayed after device reconnect
+            # https://github.com/AlexxIT/SonoffLAN/issues/1669
+            if trig_time := (params.get("trigTime") or params.get("actionTime")):
+                if trig_time == self.last_trig_time:
+                    return
+                self.last_trig_time = trig_time
+            button_params = params
         # local click: {'triggerType': 11, 'localKeyPass': {'outlet': 0, 'key': 0}}
         # local trash: {'triggerType': 0, 'localKeyPass': {'outlet': 0, 'key': 0}}
         elif params.get("triggerType"):
@@ -442,12 +457,14 @@ class XButtonLocalKey(XButtonBase):
             if seq == self.last_seq:
                 return
             self.last_seq = seq
-        else:
+            button_params = params.get("localKeyPass")
+
+        if button_params is None:
             return
 
         # MINI-2GS https://github.com/AlexxIT/SonoffLAN/issues/1694
         # MINI-ZB2GS-L https://github.com/AlexxIT/SonoffLAN/issues/1701
-        XButtonBase.set_state(self, params["localKeyPass"])
+        XButtonBase.set_state(self, button_params)
 
 
 class XT5Action(XEventSesor):

--- a/custom_components/sonoff/sensor.py
+++ b/custom_components/sonoff/sensor.py
@@ -371,7 +371,7 @@ class XWiFiDoorBattery(XSensor):
         return self.ewelink.cloud.online
 
 
-BUTTON_STATES = ["single", "double", "long", "triple"]
+BUTTON_STATES = ["single", "double", "hold"]
 
 
 class XEventSesor(XEntity, SensorEntity):
@@ -390,7 +390,7 @@ class XButtonBase(XEventSesor):
         button = params.get("outlet")
         key = BUTTON_STATES[params["key"]]
         self._attr_native_value = (
-            f"{key}_button_{button + 1}" if button is not None else key
+            f"button_{button + 1}_{key}" if button is not None else key
         )
         asyncio.create_task(self.clear_state())
 
@@ -421,9 +421,6 @@ class XButtonLocalKey(XButtonBase):
     def __init__(self, ewelink: XRegistry, device: dict):
         super().__init__(ewelink, device)
         self.last_seq = None
-        # remember initial trigTime/actionTime so stale replays after reconnect are skipped
-        params = device["params"]
-        self.last_trig_time = params.get("trigTime") or params.get("actionTime")
 
     def set_state(self, params: dict):
         if seq := self.device.get("local_seq"):
@@ -435,21 +432,9 @@ class XButtonLocalKey(XButtonBase):
         if self._attr_native_value:
             return
 
-        # Extract params from nested localKeyPass or top-level format
-        button_params = None
-
         # cloud click: {'localKeyPass': {'outlet': 0, 'key': 0}}
         if len(params) == 1:
-            button_params = params.get("localKeyPass")
-        # cloud click (new format): {'key': 0, 'outlet': 0, 'actionTime': '...'}
-        elif "key" in params and ("outlet" in params or "actionTime" in params):
-            # skip stale events replayed after device reconnect
-            # https://github.com/AlexxIT/SonoffLAN/issues/1669
-            if trig_time := (params.get("trigTime") or params.get("actionTime")):
-                if trig_time == self.last_trig_time:
-                    return
-                self.last_trig_time = trig_time
-            button_params = params
+            pass
         # local click: {'triggerType': 11, 'localKeyPass': {'outlet': 0, 'key': 0}}
         # local trash: {'triggerType': 0, 'localKeyPass': {'outlet': 0, 'key': 0}}
         elif params.get("triggerType"):
@@ -457,14 +442,12 @@ class XButtonLocalKey(XButtonBase):
             if seq == self.last_seq:
                 return
             self.last_seq = seq
-            button_params = params.get("localKeyPass")
-
-        if button_params is None:
+        else:
             return
 
         # MINI-2GS https://github.com/AlexxIT/SonoffLAN/issues/1694
         # MINI-ZB2GS-L https://github.com/AlexxIT/SonoffLAN/issues/1701
-        XButtonBase.set_state(self, button_params)
+        XButtonBase.set_state(self, params["localKeyPass"])
 
 
 class XT5Action(XEventSesor):

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-    "name": "Sonoff LAN",
+    "name": "Sonoff LAN - Fork",
     "homeassistant": "2023.2.0",
     "render_readme": true
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-    "name": "Sonoff LAN - Fork",
+    "name": "Sonoff LAN",
     "homeassistant": "2023.2.0",
     "render_readme": true
 }

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -774,7 +774,7 @@ def test_sonoff_r5():
             },
         },
     )
-    assert button.state == "double_button_3"
+    assert button.state == "button_3_double"
 
 
 def test_zigbee_th():
@@ -2312,7 +2312,7 @@ def test_zb2gs():
         SIGNAL_UPDATE,
         {"deviceid": DEVICEID, "params": {"localKeyPass": {"key": 0, "outlet": 0}}},
     )
-    assert button.state == "single_button_1"
+    assert button.state == "button_1_single"
 
 
 def test_m5_matter():
@@ -2342,7 +2342,7 @@ def test_m5_matter():
         SIGNAL_UPDATE,
         {"deviceid": DEVICEID, "params": {"localKeyPass": {"key": 0, "outlet": 0}}},
     )
-    assert button.state == "single_button_1"
+    assert button.state == "button_1_single"
 
     # this is first local event with trigger (device discovery)
     setattr(button, "_attr_native_value", "")  # reset state
@@ -2366,7 +2366,7 @@ def test_m5_matter():
             "seq": 2,
         },
     )
-    assert button.state == "single_button_2"
+    assert button.state == "button_2_single"
 
     # this is local event with same sequence
     setattr(button, "_attr_native_value", "")  # reset state

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -774,7 +774,7 @@ def test_sonoff_r5():
             },
         },
     )
-    assert button.state == "button_3_double"
+    assert button.state == "double_button_3"
 
 
 def test_zigbee_th():
@@ -2312,7 +2312,7 @@ def test_zb2gs():
         SIGNAL_UPDATE,
         {"deviceid": DEVICEID, "params": {"localKeyPass": {"key": 0, "outlet": 0}}},
     )
-    assert button.state == "button_1_single"
+    assert button.state == "single_button_1"
 
 
 def test_m5_matter():
@@ -2342,7 +2342,7 @@ def test_m5_matter():
         SIGNAL_UPDATE,
         {"deviceid": DEVICEID, "params": {"localKeyPass": {"key": 0, "outlet": 0}}},
     )
-    assert button.state == "button_1_single"
+    assert button.state == "single_button_1"
 
     # this is first local event with trigger (device discovery)
     setattr(button, "_attr_native_value", "")  # reset state
@@ -2366,7 +2366,7 @@ def test_m5_matter():
             "seq": 2,
         },
     )
-    assert button.state == "button_2_single"
+    assert button.state == "single_button_2"
 
     # this is local event with same sequence
     setattr(button, "_attr_native_value", "")  # reset state

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -53,6 +53,7 @@ from custom_components.sonoff.sensor import (
     XButtonLocalKey,
     XCloudEnergyDualR3,
     XEnergyTotal,
+    XOrb,
     XOutdoorTempNS,
     XSensor,
     XT5Action,
@@ -775,6 +776,75 @@ def test_sonoff_r5():
         },
     )
     assert button.state == "button_3_double"
+
+
+def test_snzb_01m_orb():
+    """Test SNZB-01M Orb 4-button multi-action remote.
+    
+    Orb uses new state format: {action}_button_{number}
+    - Outlets: 0-3 (buttons 1-4)
+    - Keys: 0=single, 1=double, 2=long, 3=triple
+    """
+    entities = get_entitites(
+        {
+            "extra": {"uiid": 7039},
+            "params": {
+                "subDevId": "ffffd4a21038c1a47039",
+                "parentid": "10022bcf8f",
+                "key": 0,
+                "outlet": 0,
+                "battery": 100,
+                "subDevRssi": -45,
+                "actionTime": "2026-04-26T18:23:30.000Z",
+            },
+        }
+    )
+
+    # XOrb, Battery, ZRSSI
+    assert len(entities) == 3
+    
+    orb: XOrb = next(e for e in entities if isinstance(e, XOrb))
+    assert orb.state == ""
+
+    # Button 1, single press (key=0, outlet=0)
+    orb.ewelink.cloud.dispatcher_send(
+        SIGNAL_UPDATE,
+        {
+            "deviceid": DEVICEID,
+            "params": {"key": 0, "outlet": 0, "actionTime": "2026-05-28T13:11:10.000Z"},
+        },
+    )
+    assert orb.state == "single_button_1"
+
+    # Button 2, double press (key=1, outlet=1)
+    orb.ewelink.cloud.dispatcher_send(
+        SIGNAL_UPDATE,
+        {
+            "deviceid": DEVICEID,
+            "params": {"key": 1, "outlet": 1, "actionTime": "2026-05-28T13:11:13.000Z"},
+        },
+    )
+    assert orb.state == "double_button_2"
+
+    # Button 3, long press (key=2, outlet=2)
+    orb.ewelink.cloud.dispatcher_send(
+        SIGNAL_UPDATE,
+        {
+            "deviceid": DEVICEID,
+            "params": {"key": 2, "outlet": 2, "actionTime": "2026-05-28T13:11:16.000Z"},
+        },
+    )
+    assert orb.state == "long_button_3"
+
+    # Button 4, triple press (key=3, outlet=3)
+    orb.ewelink.cloud.dispatcher_send(
+        SIGNAL_UPDATE,
+        {
+            "deviceid": DEVICEID,
+            "params": {"key": 3, "outlet": 3, "actionTime": "2026-05-28T13:11:18.000Z"},
+        },
+    )
+    assert orb.state == "triple_button_4"
 
 
 def test_zigbee_th():


### PR DESCRIPTION
# Add SNZB-01M Orb 4-Button Remote Support

## Description
This PR adds support for the SNZB-01M Orb multi-action remote (device ID 7039) to the Sonoff LAN integration.

## Changes

### Device Registration
- Registered device ID 7039 (SNZB-01M Orb) with `XOrb`, `Battery`, and `ZRSSI` entities

### New XOrb Entity Class
- Implemented `XOrb` class extending `XButtonBase` for the Orb remote
- Supports 4 buttons with 4 action types each (single, double, long, triple presses)
- Uses new state format: `{action}_button_{number}` (e.g., "single_button_1", "double_button_2")
- Implements replay protection using `trigTime`/`actionTime` to skip stale events after device reconnect
- Maps device outlet (0-3) to button numbers (1-4)

### State Mapping
- **Keys (actions)**: 0=single, 1=double, 2=long, 3=triple
- **Outlets (buttons)**: 0-3 map to buttons 1-4
