### PR TITLE
Reduce eWeLink cloud API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Home Assistant custom component for control [Sonoff](https://www.itead.cc/) devices with [eWeLink](https://www.ewelink.cc/en/) (original) firmware over LAN and/or Cloud.
 
 > [!CAUTION]
-> Starting in 2026 - power, current, and voltage sensors will no longer be updated via the cloud connection. These updates placed a heavy load on the eWeLink cloud. As a result, they were blocked by the cloud.
+> Starting in 2026 - power, current, and voltage sensors will no longer be updated via the cloud connection. These updates placed a heavy load on the eWeLink cloud. As a result, they were blocked by the cloud. The integration reduces eWeLink API calls and refreshes live power telemetry locally when LAN is available.
 
 <details>
 <summary><b>Table of Contents</b></summary>
@@ -108,9 +108,11 @@ Devices in DIY mode can be used without ewelink credentials because their protoc
 
 It is **highly recommended** that you use `mode: auto` and do not use `mode: local` or DIY mode. Because the local protocol is not always stable and you will get a bad experience. Devices may sometimes disappear from the network or fail to respond to local requests. Also some POW and TH devices cannot update their sensors without a cloud connection.
 
+To reduce eWeLink API calls, cloud requests are rate limited across all Sonoff accounts in the integration. Background cloud refreshes also have a per-device cooldown and are skipped instead of queued when the shared cloud budget is busy.
+
 ### Debug page
 
-Enable debug page in integration configuration (gear) via UI. Reload integrations page. Open: Integraion > Menu (top right dots) > Known issues.
+Enable debug page in integration configuration (gear) via UI. Reload integrations page. Open: Integration > Menu (top right dots) > Known issues.
 
 Debug page shows only integration logs and removes some private data. You can filter log and enable auto refresh (in seconds).
 
@@ -282,7 +284,8 @@ sonoff:
 
 Check which devices support the local protocol here - [DEVICES](DEVICES.md). Depending on your environment settings, the local protocol may not work. Every device has a connection sensor (disabled by default). You can check which protocol your specific device is using with this sensor.
 
-Support `power`, `current` and `voltage` sensors via **local** connection.
+Support `power`, `current` and `voltage` sensors via **local** connection. When
+LAN is available, live power telemetry is refreshed locally.
 
 The **S60TPF** device automatically sends power data to the cloud whenever the day energy sensor reading increases by 1W. Therefore, even with a cloud connection, the data will update very slowly, depending on consumption. I don't know if other device models do the same.
 
@@ -295,7 +298,10 @@ Supports two types of `energy`, depending on the device model:
   - Sensor name: `energy`, `energy_1`, `energy_2`...
   - UIID (HW version): 5, 32, 126, 130, 182, 190
 
-By default, historical `energy` data loads from cloud every hour. You can change interval via YAML and add history data to sensor attributes (max size - 30 days, disable - 0). For multi-channel devices use `energy_1`, `energy_2`.
+By default, historical `energy` data loads from cloud every hour. These requests
+use the shared cloud rate limit and per-device cooldown. You can change interval
+via YAML and add history data to sensor attributes (max size - 30 days, disable - 0).
+For multi-channel devices use `energy_1`, `energy_2`.
 
 ```yaml
 sonoff:
@@ -325,7 +331,7 @@ sensor:
 ## Sonoff TH
 
 > [!IMPORTANT]
-> For the THR316D/THR320D models, temperature and humidity sensor updates only work when connected locally. It's the same issue as with power devices - the message at the beginning of the readme file.
+> For the THR316D/THR320D models, temperature and humidity sensor updates only work when connected locally.
 
 Support optional [Climate](https://www.home-assistant.io/integrations/climate/) entity that controls Thermostat. You can control low and high temperature values and hvac modes:
 

--- a/custom_components/sonoff/core/ewelink/__init__.py
+++ b/custom_components/sonoff/core/ewelink/__init__.py
@@ -12,6 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 
 SIGNAL_ADD_ENTITIES = "add_entities"
 LOCAL_TTL = 60
+LOCAL_POWER_UIIDS = {5, 32, 182, 190, 226, 262, 276, 277}
 
 
 class XRegistry(XRegistryBase):
@@ -191,11 +192,15 @@ class XRegistry(XRegistryBase):
             return await self.send(device, params)
 
     async def send_cloud(
-        self, device: XDevice, params: dict = None, query=True
+        self,
+        device: XDevice,
+        params: dict = None,
+        query=True,
+        background: bool = False,
     ) -> str | None:
         if not self.can_cloud(device):
             return None
-        ok = await self.cloud.send(device, params)
+        ok = await self.cloud.send(device, params, throttle_device=background)
         if ok == "online" and query and params:
             await self.cloud.send(device, timeout=0)
         return ok
@@ -334,12 +339,24 @@ class XRegistry(XRegistryBase):
             and device["localfail"] < 3  # no more than 3 times
         ):
             uiid = device["extra"]["uiid"]
-            # TH10R2 (15) and THR316D/THR320D (181) shouldn't be here, but anyway
-            if uiid in (15, 32, 181, 182, 190, 262, 277):
-                if led := device["params"].get("sledOnline"):
+            if uiid in LOCAL_POWER_UIIDS:
+                if "sledOnline" in device["params"]:
+                    led = device["params"]["sledOnline"]
                     params = {"sledOnline": led}
                     asyncio.create_task(self.send_local(device, "sledonline", params))
-                    return
+                else:
+                    asyncio.create_task(
+                        self.send_local(device, "uiActive", {"uiActive": 60})
+                    )
+                return
+
+            # TH10R2 (15) and THR316D/THR320D (181) shouldn't be here, but anyway
+            if uiid in (15, 181):
+                if "sledOnline" in device["params"]:
+                    led = device["params"]["sledOnline"]
+                    params = {"sledOnline": led}
+                    asyncio.create_task(self.send_local(device, "sledonline", params))
+                return
             elif uiid == 126:
                 asyncio.create_task(self.send_local(device, "statistics"))
                 return

--- a/custom_components/sonoff/core/ewelink/cloud.py
+++ b/custom_components/sonoff/core/ewelink/cloud.py
@@ -9,6 +9,7 @@ import hmac
 import json
 import logging
 import time
+from collections import deque
 
 from aiohttp import (
     ClientConnectorError,
@@ -247,6 +248,10 @@ REGIONS = {
 DATA_ERROR = {0: "online", 503: "offline", 504: "timeout", None: "unknown"}
 
 APP = ["R8Oq3y0eSZSYdKccHlrQzT1ACCOUT9Gv"]
+CLOUD_MIN_INTERVAL = 1.0
+CLOUD_RATE_WINDOW = 300
+CLOUD_MAX_CALLS = 300
+CLOUD_DEVICE_MIN_INTERVAL = 30.0
 
 
 class AuthError(Exception):
@@ -300,13 +305,15 @@ def sign(msg: bytes) -> bytes:
 class XRegistryCloud(ResponseWaiter, XRegistryBase):
     auth: dict | None = None
     devices: dict[str, dict] = None
-    last_ts: float = 0
     last_ui_active: float = 0
     online: bool | None = None
     region: str = None
 
     task: asyncio.Task | None = None
     ws: ClientWebSocketResponse = None
+    calls: deque = deque()
+    device_calls: dict[str, float] = {}
+    throttle_lock: asyncio.Lock = asyncio.Lock()
 
     @property
     def host(self) -> str:
@@ -354,6 +361,7 @@ class XRegistryCloud(ResponseWaiter, XRegistryBase):
             "Content-Type": "application/json",
             "X-CK-Appid": APP[0],
         }
+        await self.throttle()
         r = await self.session.post(
             self.host + "/v2/user/login", data=data, headers=headers, timeout=5
         )
@@ -362,6 +370,7 @@ class XRegistryCloud(ResponseWaiter, XRegistryBase):
         # wrong default region
         if resp["error"] == 10004:
             self.region = resp["data"]["region"]
+            await self.throttle()
             r = await self.session.post(
                 self.host + "/v2/user/login", data=data, headers=headers, timeout=5
             )
@@ -377,6 +386,7 @@ class XRegistryCloud(ResponseWaiter, XRegistryBase):
 
     async def login_token(self, token: str, app: int = 0) -> bool:
         headers = {"Authorization": "Bearer " + token, "X-CK-Appid": APP[0]}
+        await self.throttle()
         r = await self.session.get(
             self.host + "/v2/user/profile", headers=headers, timeout=5
         )
@@ -391,6 +401,7 @@ class XRegistryCloud(ResponseWaiter, XRegistryBase):
         return True
 
     async def get_homes(self) -> dict:
+        await self.throttle()
         r = await self.session.get(
             self.host + "/v2/family", headers=self.headers, timeout=10
         )
@@ -400,6 +411,7 @@ class XRegistryCloud(ResponseWaiter, XRegistryBase):
     async def get_devices(self, homes: list = None) -> list[dict]:
         devices = []
         for home in homes or [None]:
+            await self.throttle()
             r = await self.session.get(
                 self.host + "/v2/device/thing",
                 headers=self.headers,
@@ -421,6 +433,7 @@ class XRegistryCloud(ResponseWaiter, XRegistryBase):
     async def set_device(self, device: XDevice, params: dict, timeout: float = 5):
         did = device["deviceid"]
         try:
+            await self.throttle()
             r = await self.session.post(
                 self.host + "/v2/device/thing/status",
                 headers=self.headers,
@@ -432,12 +445,48 @@ class XRegistryCloud(ResponseWaiter, XRegistryBase):
         except Exception as e:
             _LOGGER.debug(f"{did} => Cloud5 | {params} <= {repr(e)}")
 
+    async def throttle(self, deviceid: str = None, wait: bool = True) -> bool:
+        """Keep cloud calls inside published eWeLink API limits."""
+        while True:
+            async with self.throttle_lock:
+                now = time.time()
+
+                while self.calls and now - self.calls[0] >= CLOUD_RATE_WINDOW:
+                    self.calls.popleft()
+
+                delay = 0
+                if self.calls:
+                    delay = max(delay, self.calls[-1] + CLOUD_MIN_INTERVAL - now)
+                if len(self.calls) >= CLOUD_MAX_CALLS:
+                    delay = max(delay, self.calls[0] + CLOUD_RATE_WINDOW - now)
+                if deviceid and deviceid in self.device_calls:
+                    delay = max(
+                        delay,
+                        self.device_calls[deviceid]
+                        + CLOUD_DEVICE_MIN_INTERVAL
+                        - now,
+                    )
+
+                if delay <= 0:
+                    self.calls.append(now)
+                    if deviceid:
+                        self.device_calls[deviceid] = now
+                    return True
+
+                if not wait:
+                    _LOGGER.debug(f"Cloud rate limit skip {delay:.1f}s")
+                    return False
+
+            _LOGGER.debug(f"Cloud rate limit wait {delay:.1f}s")
+            await asyncio.sleep(delay)
+
     async def send(
         self,
         device: XDevice,
         params: dict = None,
         sequence: str = None,
         timeout: float = 5,
+        throttle_device: bool = False,
     ):
         """With params - send new state to device, without - request device
         state. With zero timeout - won't wait response.
@@ -453,11 +502,9 @@ class XRegistryCloud(ResponseWaiter, XRegistryBase):
                 await asyncio.sleep(delay)
             self.last_ui_active = time.time()
 
-        # protect cloud from DDoS (it can break connection)
-        while (delay := self.last_ts + 0.1 - time.time()) > 0:
-            log += "DDoS | "
-            await asyncio.sleep(delay)
-        self.last_ts = time.time()
+        did = device["deviceid"] if throttle_device else None
+        if not await self.throttle(did, wait=not throttle_device):
+            return "throttle"
 
         if sequence is None:
             sequence = await self.sequence()
@@ -550,6 +597,7 @@ class XRegistryCloud(ResponseWaiter, XRegistryBase):
     async def connect(self) -> bool:
         try:
             # https://coolkit-technologies.github.io/eWeLink-API/#/en/APICenterV2?id=http-dispatchservice-app
+            await self.throttle()
             r = await self.session.get(self.ws_host, headers=self.headers)
             resp = await r.json()
 
@@ -571,6 +619,7 @@ class XRegistryCloud(ResponseWaiter, XRegistryBase):
                 "sequence": str(int(ts * 1000)),
                 "version": 8,
             }
+            await self.throttle()
             await self.ws.send_json(payload)
 
             resp = await self.ws.receive_json()

--- a/custom_components/sonoff/sensor.py
+++ b/custom_components/sonoff/sensor.py
@@ -237,7 +237,11 @@ class XCloudEnergy(XEntity, SensorEntity):
         return self.available and self.ewelink.cloud.online
 
     async def get_update(self) -> bool:
-        ok = await self.ewelink.send_cloud(self.device, self.get_params, query=False)
+        ok = await self.ewelink.send_cloud(
+            self.device, self.get_params, query=False, background=True
+        )
+        if ok == "throttle":
+            self.next_ts = time.time() + min(self.report_dt, 300)
         return ok == "online"
 
     async def async_update(self):


### PR DESCRIPTION
## Summary
- keep existing `auto` / `local` / `cloud` mode selection unchanged
- keep the existing power sensor cloud warning, with a note that LAN telemetry is used when available
- add shared eWeLink cloud rate limiting across Sonoff accounts
- skip background cloud refreshes instead of queueing them when the shared cloud budget is busy
- add a per-device cooldown for background cloud refreshes
- refresh live power/current/voltage over LAN when devices support local telemetry

## Testing
- `python -m compileall custom_components\\sonoff tests`
- `git diff --check master`
- direct throttle behavior check
- live-tested on Home Assistant 2026.6.0b0:
  - Sonoff integration loads after restart
  - S40 power/current/voltage telemetry updates over LAN
  - M5-3C switch command used by `light.leds` succeeds over LAN

Full pytest was not run because it requires installing Home Assistant locally.