### PR TITLE
Fix hw_version device info type

### DIFF
--- a/custom_components/sonoff/core/entity.py
+++ b/custom_components/sonoff/core/entity.py
@@ -75,6 +75,10 @@ class XEntity(Entity):
             {(CONNECTION_NETWORK_MAC, params["staMac"])} if "staMac" in params else None
         )
 
+        hw_version = device.get("extra", {}).get("uiid")
+        if hw_version is not None:
+            hw_version = str(hw_version)
+
         self._attr_device_info = DeviceInfo(
             connections=connections,
             identifiers={(DOMAIN, deviceid)},
@@ -82,7 +86,7 @@ class XEntity(Entity):
             model=device.get("productModel"),
             name=device["name"],
             sw_version=params.get("fwVersion"),
-            hw_version=device.get("extra", {}).get("uiid"),
+            hw_version=hw_version,
         )
 
         try:

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -114,6 +114,7 @@ def test_simple_switch():
     assert switch.device_info["manufacturer"] == "SONOFF"
     assert switch.device_info["model"] == "MINI"
     assert switch.device_info["sw_version"] == "3.3.0"
+    assert switch.device_info["hw_version"] == "1"
     assert switch.state == "on"
 
     led: XToggle = next(e for e in entities if e.uid == "led")


### PR DESCRIPTION
## Summary
- Convert the Sonoff `uiid` value to a string before passing it as `hw_version` in `DeviceInfo`.
- Add test coverage to assert `hw_version` is exposed as a string.

## Why
Home Assistant now warns when custom integrations pass non-string values to the device registry for `hw_version`. Sonoff devices store `extra.uiid` as an integer, so this warning appears when entities are added.

Fixes #1804.

## Validation
- Applied the same change locally in my Home Assistant custom component setup and it works fine.
- `python3 -B -m py_compile custom_components/sonoff/core/entity.py tests/test_entity.py`
- `python3 -m pytest tests -q` in the Home Assistant container: 85 passed.
