### PR TITLE
Fix XSensor default class name stripping co2 to co

### DIFF
--- a/custom_components/sonoff/sensor.py
+++ b/custom_components/sonoff/sensor.py
@@ -38,7 +38,7 @@ async def async_setup_entry(hass, config_entry, add_entities):
 DEVICE_CLASSES = {
     "battery": SensorDeviceClass.BATTERY,
     "battery_voltage": SensorDeviceClass.VOLTAGE,
-    "co2": SensorDeviceClass.CO2,
+    "co": SensorDeviceClass.CO2,
     "cpu_temperature": SensorDeviceClass.TEMPERATURE,
     "current": SensorDeviceClass.CURRENT,
     "current_supply": SensorDeviceClass.CURRENT,
@@ -55,7 +55,7 @@ DEVICE_CLASSES = {
 UNITS = {
     "battery": PERCENTAGE,
     "battery_voltage": UnitOfElectricPotential.VOLT,
-    "co2": CONCENTRATION_PARTS_PER_MILLION,
+    "co": CONCENTRATION_PARTS_PER_MILLION,
     "cpu_temperature": UnitOfTemperature.CELSIUS,
     "current": UnitOfElectricCurrent.AMPERE,
     "current_supply": UnitOfElectricCurrent.AMPERE,
@@ -90,12 +90,8 @@ class XSensor(XEntity, SensorEntity):
         if self.param and self.uid is None:
             self.uid = self.param
 
-        # remove tailing digits (_1 _2 _3 _4 ...)
-        default_class = self.uid
-        if "_" in self.uid:
-            base_class, suffix = self.uid.rsplit("_", 1)
-            if suffix.isdigit():
-                default_class = base_class
+        # remove tailing _1 _2 _3 _4
+        default_class = self.uid.rstrip("_01234")
 
         if device["params"].get(self.param) in ("on", "off"):
             default_class = None

--- a/custom_components/sonoff/sensor.py
+++ b/custom_components/sonoff/sensor.py
@@ -90,8 +90,12 @@ class XSensor(XEntity, SensorEntity):
         if self.param and self.uid is None:
             self.uid = self.param
 
-        # remove tailing _1 _2 _3 _4
-        default_class = self.uid.rstrip("_01234")
+        # remove tailing digits (_1 _2 _3 _4 ...)
+        default_class = self.uid
+        if "_" in self.uid:
+            base_class, suffix = self.uid.rsplit("_", 1)
+            if suffix.isdigit():
+                default_class = base_class
 
         if device["params"].get(self.param) in ("on", "off"):
             default_class = None

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -11,8 +11,10 @@ from homeassistant.components.light import (
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import (
+    CONCENTRATION_PARTS_PER_MILLION,
     MAJOR_VERSION,
     MINOR_VERSION,
+    UnitOfElectricCurrent,
     UnitOfEnergy,
     UnitOfVolume,
 )
@@ -2602,30 +2604,6 @@ def test_sawf_08p():
 
     co2: XSensor = next(e for e in entities if e.uid == "co2")
     assert co2.state == 510
-
-
-def test_sawf_08p():
-    # https://github.com/AlexxIT/SonoffLAN/issues/1809
-    entities = get_entitites(
-        {
-            "extra": {"uiid": 266},
-            "params": {
-                "co2": 510,
-                "humidity": "47.3",
-                "temperature": "21.0",
-                "temperatureF": "69.8",
-                "humCorrection": "0.0",
-                "rssi": -49,
-                "sensorLight": True,
-                "sensorLightBr": 35,
-                "tempCorrection": "0.5",
-                "tempUnit": 0,
-            },
-        }
-    )
-
-    temperature: XSensor = next(e for e in entities if e.uid == "temperature")
-    assert temperature.state == 21.5
-
-    co2: XSensor = next(e for e in entities if e.uid == "co2")
-    assert co2.state == 510
+    assert co2.device_class == SensorDeviceClass.CO2
+    assert co2.native_unit_of_measurement == CONCENTRATION_PARTS_PER_MILLION
+    assert co2.state_class == SensorStateClass.MEASUREMENT


### PR DESCRIPTION
Hey Alexx, figured out what my issue was in #1817 !

The previous default sensor class inference used rstrip("_01234"), which removed any matching trailing characters. That caused `co2` to become `co`, so the sensor never received its Home Assistant attributes like `device_class`, `unit_of_measurement`.

This PR changes the logic to only strip an underscore-delimited numeric suffix, preserving names like `co2` while still supporting suffixes such as `current_0` and `current_012`.

With the fix the data now appears correctly in Home Assistant:

<img width="558" height="475" alt="image" src="https://github.com/user-attachments/assets/fe7484d4-abbb-4955-a618-e68bbc61e795" />

<img width="305" height="403" alt="image" src="https://github.com/user-attachments/assets/3ddd21a2-c80b-4ae5-89dc-830d71616b17" />


I made the sawf_08p test a bit stronger and removed the duplicate test.

Fixes #1817 