### PR TITLE
Improve LAN discovery and energy polling fallback

### DIFF
--- a/custom_components/sonoff/core/ewelink/__init__.py
+++ b/custom_components/sonoff/core/ewelink/__init__.py
@@ -92,7 +92,7 @@ class XRegistry(XRegistryBase):
         cmd_lan: str = None,
         query_cloud: bool = True,
         timeout_lan: int = 1,
-    ) -> None:
+    ) -> str | None:
         """Send command to device with LAN and Cloud. Usual params are same.
 
         LAN will send new device state after update command, Cloud - don't.
@@ -145,7 +145,9 @@ class XRegistry(XRegistryBase):
                 await self.cloud.send(device, timeout=0)
 
         else:
-            return
+            return None
+
+        return ok
 
     async def send_bulk(self, device: XDevice, params: dict):
         assert "switches" in params
@@ -279,6 +281,10 @@ class XRegistry(XRegistryBase):
             # unencripted device with devicekey in config, this means that the
             # DIY device is still connected to the ewelink account
             device.pop("devicekey")
+
+        if isinstance(params.get("config"), dict):
+            params = {**params, **params["config"]}
+            params.pop("config")
 
         # realid can be different from mainid for SPM-4RELAY
         realid = msg.get("subdevid", mainid)

--- a/custom_components/sonoff/core/ewelink/local.py
+++ b/custom_components/sonoff/core/ewelink/local.py
@@ -12,6 +12,7 @@ import ipaddress
 import json
 import logging
 import os
+import re
 
 import aiohttp
 from aiohttp.hdrs import CONTENT_TYPE
@@ -23,6 +24,14 @@ from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo
 from .base import SIGNAL_CONNECTED, SIGNAL_UPDATE, XDevice, XRegistryBase
 
 _LOGGER = logging.getLogger(__name__)
+DEVICE_ID_RE = re.compile(r"^ewelink[-_]?([0-9a-z]{10})(?:[._-]|$)", re.I)
+
+
+def parse_deviceid_from_service_name(name: str) -> str | None:
+    match = DEVICE_ID_RE.match(name)
+    if not match:
+        return None
+    return match.group(1)
 
 
 def encrypt(payload: dict, devicekey: str):
@@ -86,14 +95,16 @@ class XRegistryLocal(XRegistryBase):
             return
         # accept: eWeLink_1000xxxxxx and eWelink_1000xxxxxx (from uiid 104)
         # skip: ihost-1001xxxxxx, zbbridgeu-100xxxxxxx, zbbridgeu-100xxxxxxx-wlan0
-        if not name.lower().startswith("ewelink"):
+        deviceid = parse_deviceid_from_service_name(name)
+        if not deviceid:
             return
 
-        asyncio.create_task(self._handler2(zeroconf, service_type, name))
+        asyncio.create_task(self._handler2(zeroconf, service_type, name, deviceid))
 
-    async def _handler2(self, zeroconf: Zeroconf, service_type: str, name: str):
+    async def _handler2(
+        self, zeroconf: Zeroconf, service_type: str, name: str, deviceid: str
+    ):
         """Step 2. Request additional info about add and update event from device."""
-        deviceid = name[8:18]
         try:
             info = AsyncServiceInfo(service_type, name)
             if not await info.async_request(zeroconf, 3000) or not info.properties:
@@ -101,16 +112,17 @@ class XRegistryLocal(XRegistryBase):
                 return
 
             # support update with empty host and host without port
+            host = None
             for addr in info.addresses:
                 # zeroconf lib should return IPv4, but better check anyway
-                addr = ipaddress.IPv4Address(addr)
+                try:
+                    addr = ipaddress.IPv4Address(addr)
+                except ipaddress.AddressValueError:
+                    continue
                 host = f"{addr}:{info.port}" if info.port else str(addr)
                 break
-            else:
-                if info.server and info.port:
-                    host = f"{info.server}:{info.port}"
-                else:
-                    host = None
+            if not host and info.server and info.port:
+                host = f"{info.server}:{info.port}"
 
             data = {
                 k.decode(): v.decode() if isinstance(v, bytes) else v

--- a/custom_components/sonoff/sensor.py
+++ b/custom_components/sonoff/sensor.py
@@ -243,10 +243,12 @@ class XCloudEnergy(XEntity, SensorEntity):
             }
 
     def can_update(self) -> bool:
-        return self.available and self.ewelink.cloud.online
+        return self.available
 
     async def get_update(self) -> bool:
-        ok = await self.ewelink.send_cloud(self.device, self.get_params, query=False)
+        ok = await self.ewelink.send(
+            self.device, self.get_params, query_cloud=False, timeout_lan=5
+        )
         return ok == "online"
 
     async def async_update(self):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2,10 +2,20 @@ import asyncio
 import json
 
 from custom_components.sonoff.core.devices import spec
-from custom_components.sonoff.core.ewelink import XDevice, XRegistry, XRegistryLocal
-from custom_components.sonoff.core.ewelink.local import decrypt, encrypt
+from custom_components.sonoff.core.ewelink import (
+    SIGNAL_UPDATE,
+    XDevice,
+    XRegistry,
+    XRegistryLocal,
+)
+from custom_components.sonoff.core.ewelink.local import (
+    decrypt,
+    encrypt,
+    parse_deviceid_from_service_name,
+)
 from custom_components.sonoff.fan import XFan
 from custom_components.sonoff.light import XLightL1
+from custom_components.sonoff.sensor import XCloudEnergy
 from . import DEVICEID, save_to
 
 
@@ -45,6 +55,85 @@ def test_bulk():
     loop.close()
 
 
+def test_send_returns_fallback_result():
+    calls = []
+    loop = asyncio.new_event_loop()
+    # noinspection PyTypeChecker
+    registry: XRegistry = XRegistry(None)
+    registry.local.online = True
+    registry.cloud.online = True
+
+    device = XDevice(deviceid=DEVICEID, local=True, online=True)
+
+    async def local_send(*args):
+        calls.append(("local", args))
+        return "timeout"
+
+    async def cloud_send(*args, **kwargs):
+        calls.append(("cloud", args, kwargs))
+        return "online"
+
+    registry.local.send = local_send
+    registry.cloud.send = cloud_send
+
+    ok = loop.run_until_complete(
+        registry.send(device, {"hundredDaysKwh": "get"}, query_cloud=False)
+    )
+    loop.close()
+
+    assert ok == "online"
+    assert [call[0] for call in calls] == ["local", "cloud"]
+
+
+def test_local_update_flattens_config_params():
+    # noinspection PyTypeChecker
+    registry: XRegistry = XRegistry(None)
+    device = XDevice(deviceid=DEVICEID, params={})
+    registry.devices = {DEVICEID: device}
+
+    updates = []
+    registry.dispatcher_connect(DEVICEID, updates.append)
+    registry.local.dispatcher_send(
+        SIGNAL_UPDATE,
+        {
+            "deviceid": DEVICEID,
+            "seq": 1,
+            "params": {"config": {"hundredDaysKwhData": "000009"}},
+        },
+    )
+
+    assert device["params"] == {"hundredDaysKwhData": "000009"}
+    assert updates == [{"hundredDaysKwhData": "000009"}]
+
+
+def test_cloud_energy_uses_normal_send_without_cloud_query():
+    loop = asyncio.new_event_loop()
+    # noinspection PyTypeChecker
+    registry: XRegistry = XRegistry(None)
+    device = XDevice(deviceid=DEVICEID, name="Device1", params={})
+    entity_cls = spec(
+        XCloudEnergy,
+        param="hundredDaysKwhData",
+        get_params={"hundredDaysKwh": "get"},
+    )
+
+    async def send(*args, **kwargs):
+        registry.send_args = args, kwargs
+        return "online"
+
+    registry.send = send
+    entity = entity_cls(registry, device)
+
+    ok = loop.run_until_complete(entity.get_update())
+    loop.close()
+
+    assert ok is True
+    assert registry.send_args == (
+        (device, {"hundredDaysKwh": "get"}),
+        {"query_cloud": False, "timeout_lan": 5},
+    )
+
+
 def test_issue_1160():
     payload = XRegistryLocal.decrypt_msg(
         {
@@ -73,6 +162,25 @@ def test_cryptography():
 
     raw = decrypt(payload, key)
     assert json.loads(raw) == params
+
+
+def test_parse_deviceid_from_service_name():
+    assert (
+        parse_deviceid_from_service_name("eWeLink_100175e200._ewelink._tcp.local.")
+        == "100175e200"
+    )
+    assert (
+        parse_deviceid_from_service_name("eWeLink-100175e200._ewelink._tcp.local.")
+        == "100175e200"
+    )
+    assert (
+        parse_deviceid_from_service_name("ewelink100175e200._ewelink._tcp.local.")
+        == "100175e200"
+    )
+    assert (
+        parse_deviceid_from_service_name("zbbridgeu-100175e200._ewelink._tcp.local.")
+        is None
+    )
 
 
 def test_cloud_zigbee_offline():


### PR DESCRIPTION
## Summary

This PR makes two small LAN-related fixes while preserving the existing cloud fallback behavior:

- make eWeLink zeroconf discovery less brittle by parsing the device id from the service name instead of slicing a fixed offset, and by skipping non-IPv4 addresses instead of aborting discovery
- allow historical energy polling to use the normal transport routing path (`send`) instead of forcing cloud-only polling
- normalize local responses that wrap payload data under `config`, so local `hundredDaysKwhData` responses can update the existing energy entity

## Why

Some eWeLink power-monitoring devices are reachable and updating over LAN, but the historical energy entity is hard-coded to `send_cloud`. For devices that answer the same energy command locally, this prevents energy from using the already available LAN transport.

The normal `send` path already implements the desired behavior in auto mode: LAN first when available, cloud fallback when LAN fails, cloud when only cloud is available. This PR lets energy polling use that existing routing without adding a new mode or removing cloud support.

## Notes

- `query_cloud=False` is preserved for energy polling to avoid an extra cloud refresh after the energy command.
- `send()` now returns its internal result so polling code can correctly decide whether the update succeeded.
- Local responses such as `{"config": {"hundredDaysKwhData": "..."}}` are flattened before dispatch so existing entities can consume them.

## Validation

- `python -m pytest -q` -> `92 passed, 5 warnings`
- Tested on an S40/UIID 182 device that returned `hundredDaysKwhData` over local `/zeroconf/hundredDaysKwh`; energy updated through the local response while remaining in normal duplex/cloud fallback mode.