### PR TITLE
Fix diagnostics redaction mutating runtime config

### DIFF
--- a/custom_components/sonoff/diagnostics.py
+++ b/custom_components/sonoff/diagnostics.py
@@ -7,11 +7,12 @@ from .core import xutils
 from .core.const import DOMAIN, PRIVATE_KEYS
 from .core.ewelink import XRegistry
 
+from copy import deepcopy
 
 async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigEntry):
     try:
         if XRegistry.config:
-            config = XRegistry.config.copy()
+            config = deepcopy(XRegistry.config)
             for k in (CONF_USERNAME, CONF_PASSWORD):
                 if config.get(k):
                     config[k] = "***"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,59 @@
+import asyncio
+from types import SimpleNamespace
+
+from custom_components.sonoff.core.const import DOMAIN
+from custom_components.sonoff.core.ewelink import XRegistry
+from custom_components.sonoff.diagnostics import async_get_config_entry_diagnostics
+
+
+class FakeHass:
+    def __init__(self):
+        self.data = {}
+
+    async def async_add_executor_job(self, func, *args):
+        return func(*args)
+
+
+def test_diagnostics_does_not_mutate_config():
+    entry = SimpleNamespace(
+        entry_id="entry1",
+        options={},
+    )
+
+    # noinspection PyTypeChecker
+    registry = XRegistry(None)
+    registry.devices = {}
+    registry.cloud.auth = None
+
+    hass = FakeHass()
+    hass.data[DOMAIN] = {
+        entry.entry_id: registry,
+    }
+
+    original_config = XRegistry.config
+
+    try:
+        XRegistry.config = {
+            "username": "user@example.com",
+            "password": "secret-password",
+            "devices": {
+                "1000123456": {
+                    "devicekey": "real-device-key",
+                }
+            },
+        }
+
+        result = asyncio.run(async_get_config_entry_diagnostics(hass, entry))
+
+        assert result["config"]["username"] == "***"
+        assert result["config"]["password"] == "***"
+        assert result["config"]["devices"]["1000123456"]["devicekey"] == "***"
+
+        assert XRegistry.config["username"] == "user@example.com"
+        assert XRegistry.config["password"] == "secret-password"
+        assert (
+                XRegistry.config["devices"]["1000123456"]["devicekey"]
+                == "real-device-key"
+        )
+    finally:
+        XRegistry.config = original_config


### PR DESCRIPTION
Fix diagnostics redaction so it no longer mutates the runtime config.

The diagnostics code now deep copies `XRegistry.config` before masking sensitive values, preventing `devicekey` from being overwritten in the original config.