### PR TITLE
Fix B1 warm color temperature payload

### DIFF
--- a/custom_components/sonoff/light.py
+++ b/custom_components/sonoff/light.py
@@ -293,7 +293,7 @@ class XLightB1(XLight):
             elif color_temp_kelvin >= 3500:
                 params = {"channel0": ch, "channel1": ch}
             else:
-                params = {"channel0": ch, "channel1": ch}
+                params = {"channel0": "0", "channel1": ch}
 
             return {
                 **params,

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1491,6 +1491,35 @@ def test_light_22():
     assert reg.call(light.async_turn_on(effect="Good Night"))[1] == params
 
 
+def test_light_22_warm_color_temp_payload():
+    entities = get_entitites(
+        {
+            "extra": {"uiid": 22},
+            "params": {
+                "channel0": "159",
+                "channel1": "159",
+                "channel2": "0",
+                "channel3": "0",
+                "channel4": "0",
+                "state": "on",
+                "type": "middle",
+                "zyx_mode": 1,
+            },
+        }
+    )
+
+    light: XLightB1 = entities[0]
+
+    assert light.get_params(255, 2500, None, None) == {
+        "channel0": "0",
+        "channel1": "255",
+        "channel2": "0",
+        "channel3": "0",
+        "channel4": "0",
+        "zyx_mode": 1,
+    }
+
+
 def test_light_l1():
     entities = get_entitites(
         {


### PR DESCRIPTION
Fix B1 warm color temperature payload.

Warm color temperatures now use only the warm channel instead of enabling both cold and warm channels.