### PR TITLE
Validate RF remote send command names

### DIFF
--- a/custom_components/sonoff/remote.py
+++ b/custom_components/sonoff/remote.py
@@ -164,7 +164,12 @@ class XRemote(XEntity, RemoteEntity):
 
             # transform button name to channel number
             if not channel.isdigit():
-                channel = next(k for k, v in self.childs.items() if v.name == channel)
+                child = next((k for k, v in self.childs.items() if v.name == channel), None)
+                if child is None:
+                    _LOGGER.error(f"Unknown RF command: {channel}")
+                    continue
+
+                channel = child
 
             # cmd param for local and for cloud mode
             await self.ewelink.send(


### PR DESCRIPTION
Avoid crashing RF remote command sending when an unknown button name is used.

Unknown named commands are now logged and skipped instead of raising `StopIteration`.