### PR TITLE
Fix static host config not enabling local polling for cross-subnet devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ sonoff:
       devicekey: xxx  # optional encription key (downloaded automatically from the cloud)
 ```
 
+`host` is useful when the device can't be found via zeroconf/mDNS discovery, ex. when
+Hass and the device sit on different subnets/VLANs that are routable but don't relay
+multicast traffic. Setting `host` here makes the integration poll that address
+directly instead of waiting for a discovery packet that will never arrive.
+
 ### Custom sensors
 
 If you want some additional device attributes as sensors:

--- a/custom_components/sonoff/__init__.py
+++ b/custom_components/sonoff/__init__.py
@@ -7,6 +7,7 @@ from homeassistant.config_entries import ConfigEntry, SOURCE_IMPORT
 from homeassistant.const import (
     CONF_DEVICES,
     CONF_DEVICE_CLASS,
+    CONF_HOST,
     CONF_MODE,
     CONF_NAME,
     CONF_PASSWORD,
@@ -87,6 +88,10 @@ CONFIG_SCHEMA = vol.Schema(
                             vol.Optional(CONF_NAME): cv.string,
                             vol.Optional(CONF_DEVICE_CLASS): vol.Any(str, list),
                             vol.Optional(CONF_DEVICEKEY): cv.string,
+                            # Static LAN address (`ip` or `ip:port`) for devices that
+                            # can't be found via zeroconf, ex. when HA and the device
+                            # sit on different subnets/VLANs but are otherwise routable.
+                            vol.Optional(CONF_HOST): cv.string,
                         },
                         extra=vol.ALLOW_EXTRA,
                     ),

--- a/custom_components/sonoff/core/ewelink/__init__.py
+++ b/custom_components/sonoff/core/ewelink/__init__.py
@@ -46,6 +46,19 @@ class XRegistry(XRegistryBase):
             except Exception:
                 pass
 
+            if "host" in device and "local" not in device:
+                # Static host from YAML config (`sonoff.devices.<id>.host`).
+                # Zeroconf never sent a packet for this device (ex. it lives on
+                # a different subnet/VLAN that isn't reachable by mDNS but is
+                # otherwise routable), so seed the local-tracking fields that
+                # run_forever()/update_local() expect, letting the periodic
+                # local ping take over from here instead of waiting forever
+                # for a discovery event that will never arrive.
+                device["local"] = False
+                device["localfail"] = 0
+                device["localping"] = 0
+                device["localrecv"] = 0
+
             try:
                 uiid = device["extra"]["uiid"]
                 _LOGGER.debug(f"{did} UIID {uiid:04} | %s", device["params"])


### PR DESCRIPTION
## Problem

The `host` option documented under `sonoff.devices.<id>` in the README is meant to let you force a device's LAN address:

```yaml
sonoff:
  devices:
    1000xxxxxx:
      host: 192.168.1.123  # optional force device IP-address
```

This reaches `device["host"]` fine via the existing config merge in `setup_devices()`:

```python
try:
    device.update(self.config["devices"][did])
except Exception:
    pass
```

But nothing ever seeds `device["local"]`, `localping`, `localfail`, `localrecv`. `run_forever()` only polls devices where `"local"` is already a key in the dict:

```python
if "local" in device:
    self.update_local(device, ts)
```

That key is only ever set inside `local_update()`, which only runs when a zeroconf packet actually arrives for that device. So a device that never gets discovered via mDNS (ex. it lives on a different subnet/VLAN that is otherwise routable but doesn't relay multicast) stays `unavailable` forever, even with a valid static `host` configured — silently contradicting what the README describes.

## Fix

In `setup_devices()`, right after the existing config merge, seed the local-tracking fields when a static `host` is present and no zeroconf event has set them yet:

```python
if "host" in device and "local" not in device:
    device["local"] = False
    device["localfail"] = 0
    device["localping"] = 0
    device["localrecv"] = 0
```

This lets the periodic local ping in `run_forever()`/`send_local()` pick the device up on its own, exactly like it would after a real discovery event — it just skips waiting for one. Also added `CONF_HOST` to the per-device config schema (was previously only accepted via `extra=vol.ALLOW_EXTRA`, undocumented in the schema itself) and expanded the README section.

## Testing

Reproduced against real hardware: a Sonoff device reachable only via routed L3 (HA host and device are on different subnets connected through several routed hops; mDNS multicast does not cross that boundary) was permanently `unavailable`. After seeding the fields above, the periodic local ping in `run_forever()` picked it up and successfully sent a real LAN request to the device's `/zeroconf/*` endpoint — confirmed via the actual (unmodified) `local.py` code path.

Motivated by a real deployment where Home Assistant runs on a management VLAN and ~150 Sonoff devices sit on a separate routed WiFi network.