### PR TITLE
Add support for SNZB-02B

### DIFF
--- a/custom_components/sonoff/core/devices.py
+++ b/custom_components/sonoff/core/devices.py
@@ -757,6 +757,13 @@ DEVICES = {
     7039: [XButtonKey, Battery, ZRSSI],
     # SWV-ZNE, https://github.com/AlexxIT/SonoffLAN/issues/1814
     7047: [spec(XBoolSwitch, param="switch_00", uid="switch"), Battery, ZRSSI],
+    # SNZB-02B
+    7052: [
+        spec(XSensor100, param="temperature"),
+        spec(XSensor100, param="humidity"),
+        Battery,
+        ZRSSI
+    ],
     # SNZB-03PR2 https://github.com/AlexxIT/SonoffLAN/issues/1824
     7055: [XHumanSensor, spec(XSensor, param="illumination"), Battery, ZRSSI],
 }


### PR DESCRIPTION
Add support for SNZB-02B.

Sample payload from the device:
```json
  "data": {
    (...)
    "device": {
      "uiid": 7052,
      "params": {
        "subDevId": "...",
        "parentid": "...",
        "fwVersion": "1.0.5",
        "battery": 100,
        "supportPowConfig": 1,
        "trigTime": "1784627019000",
        "tempUnit": 0,
        "humiComfortLower": 4000,
        "humiComfortUpper": 6000,
        "tempComfortLower": 1900,
        "tempComfortUpper": 2700,
        "tempComfortStatus": 0,
        "temperature": 2570,
        "temperatureF": 7826,
        "tempCorrection": 0,
        "humiComfortStatus": 0,
        "humidity": 4640,
        "subDevRssi": -48,
        "subDeviceManufacturer": "SONOFF",
        "humCorrection": 0
      },
      "model": "SNZB-02B",
      (...)
    }
  },
```