### PR TITLE
Improve handling of redundant cloud commands and error 411 diagnostics

### DIFF
--- a/custom_components/sonoff/__init__.py
+++ b/custom_components/sonoff/__init__.py
@@ -178,7 +178,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
             if mode == "local":
                 await registry.local.send(device, params, command)
             elif mode == "cloud":
-                await registry.cloud.send(device, params)
+                await registry.send_cloud(device, params, force=True)
             elif mode == "api":
                 await registry.cloud.set_device(device, params)
             else:
@@ -209,6 +209,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         session = create_clientsession(hass)
         hass.data[DOMAIN][config_entry.entry_id] = registry = XRegistry(session)
 
+    registry.cloud_retry = config_entry.options.get("cloud_retry", False)
     mode = config_entry.options.get(CONF_MODE, "auto")
     data = config_entry.data
 

--- a/custom_components/sonoff/config_flow.py
+++ b/custom_components/sonoff/config_flow.py
@@ -124,6 +124,7 @@ class OptionsFlowHandler(OptionsFlow):
             {
                 vol.Optional(CONF_MODE, default="auto"): vol.In(CONF_MODES),
                 vol.Optional(CONF_DEBUG, default=False): bool,
+                vol.Optional("cloud_retry", default=False): bool,
                 vol.Optional("homes"): cv.multi_select(homes),
             },
             dict(self.config_entry.options),

--- a/custom_components/sonoff/core/ewelink/__init__.py
+++ b/custom_components/sonoff/core/ewelink/__init__.py
@@ -1,16 +1,25 @@
 import asyncio
+from collections import deque
 import logging
 import time
 
 from aiohttp import ClientSession
 
-from .base import SIGNAL_CONNECTED, SIGNAL_UPDATE, XDevice, XRegistryBase
+from .base import (
+    SIGNAL_CLOUD_ERROR,
+    SIGNAL_CONNECTED,
+    SIGNAL_UPDATE,
+    XDevice,
+    XRegistryBase,
+)
 from .cloud import XRegistryCloud
 from .local import XRegistryLocal
 
 _LOGGER = logging.getLogger(__name__)
 
 SIGNAL_ADD_ENTITIES = "add_entities"
+COMMAND_ERRORS_MAXLEN = 100
+RECONCILE_DELAY = 2
 LOCAL_TTL = 60
 
 
@@ -22,9 +31,18 @@ class XRegistry(XRegistryBase):
         super().__init__(session)
 
         self.devices: dict[str, XDevice] = {}
+        self.cloud_locks: dict[str, asyncio.Lock] = {}
+        self.cloud_pending: dict[str, dict] = {}
+        self.cloud_error_tasks: dict[str, asyncio.Task] = {}
+        self.cloud_errors: deque[dict] = deque(maxlen=COMMAND_ERRORS_MAXLEN)
+        # Opt-in: a retry is safe only for explicit switch on/off commands.
+        self.cloud_retry = False
 
         self.cloud = XRegistryCloud(session)
+        # Let cloud protocol logs resolve a device ID to its local friendly name.
+        self.cloud.devices = self.devices
         self.cloud.dispatcher_connect(SIGNAL_CONNECTED, self.cloud_connected)
+        self.cloud.dispatcher_connect(SIGNAL_CLOUD_ERROR, self.cloud_error)
         self.cloud.dispatcher_connect(SIGNAL_UPDATE, self.cloud_update)
 
         self.local = XRegistryLocal(session)
@@ -77,6 +95,12 @@ class XRegistry(XRegistryBase):
         self.devices.clear()
         self.dispatcher.clear()
 
+        for task in self.cloud_error_tasks.values():
+            task.cancel()
+        self.cloud_error_tasks.clear()
+        self.cloud_pending.clear()
+        self.cloud_locks.clear()
+
         await self.cloud.stop()
         await self.local.stop()
 
@@ -127,12 +151,9 @@ class XRegistry(XRegistryBase):
 
             # otherwise send a command through the cloud
             if ok != "online":
-                ok = await self.cloud.send(device, params, seq)
+                ok = await self.send_cloud(device, params, query_cloud, seq)
                 if ok != "online":
                     main_device["localping"] = 0  # instant local ping request
-                elif query_cloud and params:
-                    # force update device actual status
-                    await self.cloud.send(device, timeout=0)
 
         elif can_local:
             ok = await self.local.send(main_device, params_lan or params, cmd_lan, seq)
@@ -140,9 +161,7 @@ class XRegistry(XRegistryBase):
                 main_device["localping"] = 0  # instant local ping request
 
         elif can_cloud:
-            ok = await self.cloud.send(device, params, seq)
-            if ok == "online" and query_cloud and params:
-                await self.cloud.send(device, timeout=0)
+            await self.send_cloud(device, params, query_cloud, seq)
 
         else:
             return
@@ -191,14 +210,223 @@ class XRegistry(XRegistryBase):
             return await self.send(device, params)
 
     async def send_cloud(
-        self, device: XDevice, params: dict = None, query=True
+        self,
+        device: XDevice,
+        params: dict = None,
+        query: bool = True,
+        sequence: str = None,
+        timeout: float = 5,
+        force: bool = False,
+        origin: str = "command",
     ) -> str | None:
-        if not self.can_cloud(device):
+        """Send one cloud command, serialised per device and safely recorded.
+
+        The bridge framework 3.3.0 cannot control Zigbee children via LAN. This
+        method deliberately uses the cloud transport only and never retries a
+        failed actuator command unless the user explicitly opts in.
+        """
+        if not force and not self.can_cloud(device):
             return None
-        ok = await self.cloud.send(device, params)
-        if ok == "online" and query and params:
-            await self.cloud.send(device, timeout=0)
+
+        did = device["deviceid"]
+        if sequence is None:
+            sequence = await self.sequence()
+
+        command = {
+            "action": "update" if params else "query",
+            "params": params.copy() if params else None,
+            "param_keys": sorted(params) if params else [],
+            "safe_retry": self.is_safe_retry(params),
+            "sequence": sequence,
+            "timestamp": time.time(),
+            "started_monotonic": time.monotonic(),
+            "origin": origin,
+            **self.cloud_context(device),
+        }
+
+        lock = self.cloud_locks.setdefault(did, asyncio.Lock())
+        async with lock:
+            # Re-check while holding the per-device lock. A previous command may
+            # have completed while this one was waiting, making a second on/off
+            # request redundant and a potential source of cloud 411 responses.
+            if self.is_redundant_switch_command(device, params):
+                _LOGGER.debug("Skip redundant cloud command for %s", did)
+                return "online"
+
+            # Keep parameter values in memory only while the command is in flight.
+            self.cloud_pending[sequence] = command
+            device["last_cloud_command"] = {
+                k: v
+                for k, v in command.items()
+                if k not in ("params", "safe_retry", "started_monotonic")
+            }
+            try:
+                ok = await self.cloud.send(device, params, sequence, timeout)
+            finally:
+                self.cloud_pending.pop(sequence, None)
+
+            if ok == "online" and query and params:
+                # Queue the state query before the next command for this device.
+                # This keeps the command order deterministic without replaying an
+                # actuator command and improves the redundant-command check above.
+                query_sequence = await self.sequence()
+                self.cloud_pending[query_sequence] = {
+                    "action": "query",
+                    "param_keys": [],
+                    "sequence": query_sequence,
+                    "started_monotonic": time.monotonic(),
+                    "origin": "post-update-query",
+                    **self.cloud_context(device),
+                }
+                try:
+                    await self.cloud.send(device, sequence=query_sequence, timeout=0)
+                finally:
+                    self.cloud_pending.pop(query_sequence, None)
+
+        command["latency_ms"] = round(
+            (time.monotonic() - command["started_monotonic"]) * 1000
+        )
+        device["last_cloud_command"]["latency_ms"] = command["latency_ms"]
+
+        if ok == "online":
+            device["last_cloud_success"] = time.time()
+
         return ok
+
+    @staticmethod
+    def cloud_context(device: XDevice) -> dict:
+        """Return useful transport context without command values or credentials."""
+        context = {"transport": "cloud"}
+        if rssi := device.get("params", {}).get("subDevRssi"):
+            context["device_rssi"] = rssi
+
+        if not (parent := device.get("parent")):
+            return context
+
+        context["parentid"] = parent.get("deviceid")
+        context["parent_model"] = parent.get("productModel")
+        if rssi := parent.get("params", {}).get("rssi"):
+            context["bridge_rssi"] = rssi
+        if version := parent.get("params", {}).get("hostVersion"):
+            context["bridge_framework"] = version
+        if parent.get("productModel") == "ZBBridge-P":
+            context["transport_reason"] = "zbbridge_child_lan_unsupported"
+        return context
+
+    @staticmethod
+    def is_safe_retry(params: dict | None) -> bool:
+        """Only explicit on/off is safe to repeat after an ambiguous timeout."""
+        return params is not None and params.get("switch") in ("on", "off") and len(
+            params
+        ) == 1
+
+    @staticmethod
+    def is_redundant_switch_command(device: XDevice, params: dict | None) -> bool:
+        """Return true only for a known, already satisfied switch state."""
+        return XRegistry.is_safe_retry(params) and (
+            device.get("params", {}).get("switch") == params["switch"]
+        )
+
+    @staticmethod
+    def is_command_confirmed(device: XDevice, command: dict, sequence: str) -> bool:
+        """Confirm that the reconciliation response reports the requested state."""
+        params = command.get("params") or {}
+        return device.get("cloud_seq") == sequence and all(
+            device.get("params", {}).get(key) == value for key, value in params.items()
+        )
+
+    def cloud_error(self, event: dict) -> None:
+        """Record a redacted cloud error and schedule one status reconciliation."""
+        did = event.get("deviceid")
+        device = self.devices.get(did)
+        command = self.cloud_pending.get(event.get("sequence"), {})
+
+        record = {
+            "code": event.get("error"),
+            "deviceid": did,
+            "sequence": event.get("sequence"),
+            "action": command.get("action", event.get("action")),
+            "param_keys": command.get("param_keys", []),
+            "timestamp": time.time(),
+        }
+        for key in (
+            "origin",
+            "transport",
+            "transport_reason",
+            "device_rssi",
+            "bridge_rssi",
+            "bridge_framework",
+        ):
+            if command.get(key) is not None:
+                record[key] = command[key]
+        if started := command.get("started_monotonic"):
+            record["latency_ms"] = round((time.monotonic() - started) * 1000)
+        if device and (parent := device.get("parent")):
+            record["parentid"] = parent.get("deviceid")
+            record["parent_model"] = parent.get("productModel")
+
+        self.cloud_errors.append(record)
+        if not device:
+            return
+
+        device["last_cloud_error"] = record
+        code = record["code"]
+        if code not in (411, 504) or did in self.cloud_error_tasks:
+            return
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # Allows synchronous unit tests and does not affect Home Assistant.
+            return
+
+        self.cloud_error_tasks[did] = loop.create_task(
+            self.reconcile_cloud_error(device, record, command)
+        )
+
+    async def reconcile_cloud_error(
+        self, device: XDevice, record: dict, command: dict
+    ) -> None:
+        """Verify state after an eWeLink 411/504 without replaying the command."""
+        did = device["deviceid"]
+        try:
+            await asyncio.sleep(RECONCILE_DELAY)
+            sequence = await self.sequence()
+            result = await self.send_cloud(
+                device,
+                query=False,
+                sequence=sequence,
+                timeout=5,
+                force=True,
+                origin="error-reconciliation",
+            )
+            confirmed = result == "online" and self.is_command_confirmed(
+                device, command, sequence
+            )
+            record["reconcile"] = {"result": result, "confirmed": confirmed}
+
+            # An opt-in retry is limited to an unconfirmed, idempotent switch set.
+            if (
+                not confirmed
+                and record["code"] in (411, 504)
+                and self.cloud_retry
+                and command.get("safe_retry")
+            ):
+                await asyncio.sleep(RECONCILE_DELAY)
+                record["retry"] = await self.send_cloud(
+                    device,
+                    command["params"],
+                    query=True,
+                    force=True,
+                    origin="error-retry",
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            record["reconcile"] = type(err).__name__
+            _LOGGER.debug("Cloud error reconciliation failed for %s", did, exc_info=err)
+        finally:
+            self.cloud_error_tasks.pop(did, None)
 
     def cloud_connected(self):
         for deviceid in self.devices.keys():
@@ -235,6 +463,8 @@ class XRegistry(XRegistryBase):
 
         if "sledOnline" in params:
             device["params"]["sledOnline"] = params["sledOnline"]
+
+        device["params"].update(params)
 
         self.dispatcher_send(did, params)
 

--- a/custom_components/sonoff/core/ewelink/__init__.py
+++ b/custom_components/sonoff/core/ewelink/__init__.py
@@ -16,9 +16,12 @@ from .cloud import XRegistryCloud
 from .local import XRegistryLocal
 
 _LOGGER = logging.getLogger(__name__)
+_CLOUD_LOGGER = logging.getLogger(f"{__name__}.cloud")
 
 SIGNAL_ADD_ENTITIES = "add_entities"
 COMMAND_ERRORS_MAXLEN = 100
+COMMAND_WARNING_MAXLEN = 256
+COMMAND_WARNING_INTERVAL = 15 * 60
 RECONCILE_DELAY = 2
 LOCAL_TTL = 60
 
@@ -35,6 +38,7 @@ class XRegistry(XRegistryBase):
         self.cloud_pending: dict[str, dict] = {}
         self.cloud_error_tasks: dict[str, asyncio.Task] = {}
         self.cloud_errors: deque[dict] = deque(maxlen=COMMAND_ERRORS_MAXLEN)
+        self.cloud_error_warnings: dict[tuple[str, int], dict] = {}
         # Opt-in: a retry is safe only for explicit switch on/off commands.
         self.cloud_retry = False
 
@@ -100,6 +104,7 @@ class XRegistry(XRegistryBase):
         self.cloud_error_tasks.clear()
         self.cloud_pending.clear()
         self.cloud_locks.clear()
+        self.cloud_error_warnings.clear()
 
         await self.cloud.stop()
         await self.local.stop()
@@ -384,10 +389,47 @@ class XRegistry(XRegistryBase):
             self.reconcile_cloud_error(device, record, command)
         )
 
+    def log_unconfirmed_cloud_error(
+        self, device: XDevice, record: dict, now: float | None = None
+    ) -> None:
+        """Log one actionable cloud failure per device/code interval.
+
+        Cloud errors can arrive in bursts while a bridge reconnects. Preserve the
+        complete bounded diagnostic history, but coalesce repeated warnings so
+        Home Assistant's system log receives only actionable data.
+        """
+        now = time.time() if now is None else now
+        key = (device["deviceid"], record["code"])
+        previous = self.cloud_error_warnings.get(key)
+
+        if previous and now - previous["timestamp"] < COMMAND_WARNING_INTERVAL:
+            previous["suppressed"] += 1
+            record["warning_suppressed"] = True
+            return
+
+        if len(self.cloud_error_warnings) >= COMMAND_WARNING_MAXLEN and not previous:
+            oldest = min(
+                self.cloud_error_warnings,
+                key=lambda item: self.cloud_error_warnings[item]["timestamp"],
+            )
+            self.cloud_error_warnings.pop(oldest)
+
+        suppressed = previous["suppressed"] if previous else 0
+        self.cloud_error_warnings[key] = {"timestamp": now, "suppressed": 0}
+        record["warning_suppressed"] = suppressed
+        _CLOUD_LOGGER.warning(
+            "Cloud command error code=%s device=%s name=%s sequence=%s suppressed=%s",
+            record["code"],
+            device["deviceid"],
+            device.get("name", "unknown"),
+            record["sequence"],
+            suppressed,
+        )
+
     async def reconcile_cloud_error(
         self, device: XDevice, record: dict, command: dict
     ) -> None:
-        """Verify state after an eWeLink 411/504 without replaying the command."""
+        """Verify an ambiguous eWeLink response before reporting it as a failure."""
         did = device["deviceid"]
         try:
             await asyncio.sleep(RECONCILE_DELAY)
@@ -412,14 +454,45 @@ class XRegistry(XRegistryBase):
                 and self.cloud_retry
                 and command.get("safe_retry")
             ):
-                await asyncio.sleep(RECONCILE_DELAY)
-                record["retry"] = await self.send_cloud(
+                retry_result = await self.send_cloud(
                     device,
                     command["params"],
-                    query=True,
+                    query=False,
                     force=True,
                     origin="error-retry",
                 )
+                await asyncio.sleep(RECONCILE_DELAY)
+                retry_sequence = await self.sequence()
+                verify_result = await self.send_cloud(
+                    device,
+                    query=False,
+                    sequence=retry_sequence,
+                    timeout=5,
+                    force=True,
+                    origin="error-retry-verification",
+                )
+                confirmed = verify_result == "online" and self.is_command_confirmed(
+                    device, command, retry_sequence
+                )
+                record["retry"] = {
+                    "result": retry_result,
+                    "verification": verify_result,
+                    "confirmed": confirmed,
+                }
+
+            if confirmed:
+                record["outcome"] = "recovered"
+                _LOGGER.info(
+                    "Cloud command response recovered code=%s device=%s name=%s sequence=%s",
+                    record["code"],
+                    did,
+                    device.get("name", "unknown"),
+                    record["sequence"],
+                )
+                return
+
+            record["outcome"] = "unconfirmed"
+            self.log_unconfirmed_cloud_error(device, record)
         except asyncio.CancelledError:
             raise
         except Exception as err:

--- a/custom_components/sonoff/core/ewelink/base.py
+++ b/custom_components/sonoff/core/ewelink/base.py
@@ -5,6 +5,7 @@ from typing import Callable, Optional, TypedDict
 from aiohttp import ClientSession
 
 SIGNAL_CONNECTED = "connected"
+SIGNAL_CLOUD_ERROR = "cloud_error"
 SIGNAL_UPDATE = "update"
 
 
@@ -34,6 +35,9 @@ class XDevice(TypedDict, total=False):
     localping: Optional[float]
 
     cloud_seq: int | None  # sequence for update from cloud (if exists - cmd from app)
+    last_cloud_command: Optional[dict]
+    last_cloud_error: Optional[dict]
+    last_cloud_success: Optional[float]
     local_seq: int | None  # sequence for update from local
 
     parent: Optional[dict]

--- a/custom_components/sonoff/core/ewelink/cloud.py
+++ b/custom_components/sonoff/core/ewelink/cloud.py
@@ -630,8 +630,11 @@ class XRegistryCloud(ResponseWaiter, XRegistryBase):
             if data.get("error", 0) not in (0, None):
                 event = cloud_error_event(data)
                 name = self.devices.get(event["deviceid"], {}).get("name")
-                _LOGGER.warning(
-                    "Cloud command error code=%s device=%s name=%s sequence=%s",
+                # A bridge child can apply a command while its cloud response is
+                # still an error (notably 411/504). The registry reconciles those
+                # replies before deciding whether this is a real failure.
+                _LOGGER.debug(
+                    "Cloud command response pending reconciliation code=%s device=%s name=%s sequence=%s",
                     event["error"],
                     event["deviceid"],
                     name or "unknown",

--- a/custom_components/sonoff/core/ewelink/cloud.py
+++ b/custom_components/sonoff/core/ewelink/cloud.py
@@ -17,7 +17,13 @@ from aiohttp import (
     WSMessage,
 )
 
-from .base import SIGNAL_CONNECTED, SIGNAL_UPDATE, XDevice, XRegistryBase
+from .base import (
+    SIGNAL_CLOUD_ERROR,
+    SIGNAL_CONNECTED,
+    SIGNAL_UPDATE,
+    XDevice,
+    XRegistryBase,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -251,6 +257,20 @@ APP = ["R8Oq3y0eSZSYdKccHlrQzT1ACCOUT9Gv"]
 
 class AuthError(Exception):
     pass
+
+
+def cloud_error_event(data: dict) -> dict:
+    """Return the useful, non-sensitive part of a cloud error response.
+
+    eWeLink WebSocket errors often contain `apikey` and `uid`. They must not be
+    persisted in Home Assistant logs or diagnostics.
+    """
+    return {
+        "error": data.get("error"),
+        "deviceid": data.get("deviceid"),
+        "sequence": data.get("sequence"),
+        "action": data.get("action"),
+    }
 
 
 class ResponseWaiter:
@@ -607,17 +627,31 @@ class XRegistryCloud(ResponseWaiter, XRegistryBase):
             if "sequence" in data:
                 self._set_response(data["sequence"], data.get("error"))
 
+            if data.get("error", 0) not in (0, None):
+                event = cloud_error_event(data)
+                name = self.devices.get(event["deviceid"], {}).get("name")
+                _LOGGER.warning(
+                    "Cloud command error code=%s device=%s name=%s sequence=%s",
+                    event["error"],
+                    event["deviceid"],
+                    name or "unknown",
+                    event["sequence"],
+                )
+                self.dispatcher_send(SIGNAL_CLOUD_ERROR, event)
+
             # with params response on query, without - on update
-            if "params" in data:
+            elif "params" in data:
                 self.dispatcher_send(SIGNAL_UPDATE, data)
             elif "config" in data:
                 data["params"] = data.pop("config")
                 self.dispatcher_send(SIGNAL_UPDATE, data)
             elif "error" in data:
-                if data["error"] != 0:
-                    _LOGGER.warning(f"Cloud ERROR: {data}")
+                # eWeLink acknowledges some updates with only the correlation
+                # fields and error=0. It is a successful acknowledgement, not
+                # an unknown cloud response.
+                pass
             else:
-                _LOGGER.warning(f"UNKNOWN cloud msg: {data}")
+                _LOGGER.warning("Unknown cloud response keys=%s", sorted(data))
 
         elif data["action"] == "update":
             # new state from device
@@ -641,7 +675,9 @@ class XRegistryCloud(ResponseWaiter, XRegistryBase):
             pass
 
         else:
-            _LOGGER.warning(f"UNKNOWN cloud msg: {data}")
+            _LOGGER.warning(
+                "Unknown cloud action=%s keys=%s", data["action"], sorted(data)
+            )
 
 
 # https://coolkit-technologies.github.io/eWeLink-API/#/en/OAuth2.0?id=websocket-handshake

--- a/custom_components/sonoff/diagnostics.py
+++ b/custom_components/sonoff/diagnostics.py
@@ -1,3 +1,8 @@
+"""Diagnostics with explicit redaction for data that may be shared publicly."""
+
+from copy import deepcopy
+from typing import Any
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -7,58 +12,131 @@ from .core import xutils
 from .core.const import DOMAIN, PRIVATE_KEYS
 from .core.ewelink import XRegistry
 
-from copy import deepcopy
+# Diagnostics can be attached to public issues. Do not expose credentials,
+# network addresses, stable device identifiers or a user's device names.
+DIAGNOSTIC_REDACT_KEYS = frozenset(
+    {
+        CONF_USERNAME,
+        CONF_PASSWORD,
+        "appid",
+        "appsecret",
+        "apikey",
+        "uid",
+        "deviceid",
+        "parentid",
+        "devicekey",
+        "host",
+        "ip",
+        "mac",
+        "name",
+        "sequence",
+        "timestamp",
+        "token",
+        "access_token",
+        "refresh_token",
+        "authorization",
+    }
+).union(key.casefold() for key in PRIVATE_KEYS)
+
+
+def redact_diagnostics_data(value: Any, secret_values: tuple[str, ...] = ()) -> Any:
+    """Return a recursively redacted diagnostics value.
+
+    ``secret_values`` is used for formatted log messages, where the sensitive
+    item is part of a string rather than the name of a mapping key.
+    """
+    if isinstance(value, dict):
+        return {
+            key: "***"
+            if str(key).casefold() in DIAGNOSTIC_REDACT_KEYS
+            else redact_diagnostics_data(item, secret_values)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_diagnostics_data(item, secret_values) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_diagnostics_data(item, secret_values) for item in value)
+    if isinstance(value, str):
+        for secret in secret_values:
+            if secret:
+                value = value.replace(secret, "***")
+    return value
+
+
+def diagnostic_secret_values(registry: XRegistry) -> tuple[str, ...]:
+    """Collect identifiers and names only for redacting formatted log strings."""
+    values = set()
+    for device in registry.devices.values():
+        for key in ("deviceid", "apikey", "devicekey", "host", "name"):
+            if value := device.get(key):
+                values.add(str(value))
+        if parent := device.get("parent"):
+            for key in ("deviceid", "apikey", "devicekey", "host", "name"):
+                if value := parent.get(key):
+                    values.add(str(value))
+
+    if config := XRegistry.config:
+        for key in ("appid", "appsecret", CONF_USERNAME, CONF_PASSWORD):
+            if value := config.get(key):
+                values.add(str(value))
+
+    return tuple(sorted(values, key=len, reverse=True))
+
+
+def device_diagnostics(device: dict, secret_values: tuple[str, ...]) -> dict:
+    """Return only useful, non-identifying device diagnostics."""
+    if "params" not in device:
+        return {"localtype": device.get("localtype")}
+
+    data = {
+        "uiid": device["extra"]["uiid"],
+        "params": device["params"],
+        "model": device.get("productModel"),
+        "online": device.get("online"),
+        "local": device.get("local"),
+        "localtype": device.get("localtype"),
+        "last_cloud_command": device.get("last_cloud_command"),
+        "last_cloud_error": device.get("last_cloud_error"),
+    }
+    return redact_diagnostics_data(data, secret_values)
+
 
 async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigEntry):
-    try:
-        if XRegistry.config:
-            config = deepcopy(XRegistry.config)
-            for k in (CONF_USERNAME, CONF_PASSWORD):
-                if config.get(k):
-                    config[k] = "***"
-            if config.get("devices"):
-                for device in config["devices"].values():
-                    if device.get("devicekey"):
-                        device["devicekey"] = "***"
-        else:
-            config = None
-    except Exception as e:
-        config = repr(e)
-
-    options = {k: len(v) if k == "homes" else v for k, v in entry.options.items()}
-
+    """Return redacted diagnostics for a config entry."""
     registry: XRegistry = hass.data[DOMAIN][entry.entry_id]
+    secret_values = diagnostic_secret_values(registry)
+
     try:
-        devices = {
-            did: (
-                {
-                    "uiid": device["extra"]["uiid"],
-                    "params": {
-                        k: "***" if k in PRIVATE_KEYS else v
-                        for k, v in device["params"].items()
-                    },
-                    "model": device.get("productModel"),
-                    "online": device.get("online"),
-                    "local": device.get("local"),
-                    "localtype": device.get("localtype"),
-                    "host": device.get("host"),
-                }
-                if "params" in device
-                else {
-                    "localtype": device.get("localtype"),
-                }
-            )
-            for did, device in registry.devices.items()
-        }
-    except Exception as e:
-        devices = repr(e)
+        config = deepcopy(XRegistry.config) if XRegistry.config else None
+        if config and config.get("devices"):
+            # Device IDs are mapping keys in this structure, so replace it with
+            # a count before applying the normal key/value redactor.
+            config["devices"] = {"count": len(config["devices"])}
+        config = redact_diagnostics_data(config, secret_values)
+    except Exception as err:
+        config = repr(err)
+
+    options = {key: len(value) if key == "homes" else value for key, value in entry.options.items()}
+
+    try:
+        devices = [
+            device_diagnostics(device, secret_values)
+            for device in registry.devices.values()
+        ]
+    except Exception as err:
+        devices = repr(err)
 
     return {
         "version": await hass.async_add_executor_job(xutils.source_hash),
         "cloud_auth": registry.cloud.auth is not None,
         "config": config,
         "options": options,
-        "errors": xutils.system_log_records(hass, DOMAIN),
+        "errors": redact_diagnostics_data(
+            xutils.system_log_records(hass, DOMAIN), secret_values
+        ),
+        "cloud_command_errors": redact_diagnostics_data(
+            list(registry.cloud_errors), secret_values
+        ),
         "devices": devices,
     }
 
@@ -66,8 +144,12 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
 async def async_get_device_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry, device: DeviceEntry
 ):
-    did = next(i[1] for i in device.identifiers if i[0] == DOMAIN)
+    """Return redacted diagnostics for one device without returning its ID."""
+    did = next(identifier[1] for identifier in device.identifiers if identifier[0] == DOMAIN)
     info = await async_get_config_entry_diagnostics(hass, entry)
-    info["device"] = info.pop("devices").get(did, {})
-    info["device"]["deviceid"] = did
+    registry: XRegistry = hass.data[DOMAIN][entry.entry_id]
+    info.pop("devices")
+    info["device"] = device_diagnostics(
+        registry.devices.get(did, {}), diagnostic_secret_values(registry)
+    )
     return info

--- a/custom_components/sonoff/translations/en.json
+++ b/custom_components/sonoff/translations/en.json
@@ -24,7 +24,8 @@
         "data": {
           "mode": "Mode (auto is recommended for most users)",
           "homes": "Homes (leave blank for active home in mobile app)",
-          "debug": "Debug page (Integration > Menu > Known issues)"
+          "debug": "Debug page (Integration > Menu > Known issues)",
+          "cloud_retry": "Retry an unconfirmed cloud on/off command after a 411 or 504 error (disabled by default)"
         }
       }
     }

--- a/custom_components/sonoff/translations/it.json
+++ b/custom_components/sonoff/translations/it.json
@@ -24,7 +24,8 @@
           "data": {
             "mode": "Modalità (per la maggior parte degli utenti lasciare su auto)",
             "homes": "Case (non specificare per selezionare quella di default sull'app)",
-            "debug": "Pagina di Debug (Integrazioni > Menu > Known issues)"
+            "debug": "Pagina di Debug (Integrazioni > Menu > Known issues)",
+            "cloud_retry": "Ritenta un comando cloud on/off non confermato dopo errore 411 o 504 (disabilitato per impostazione predefinita)"
           }
         }
       }

--- a/tests/test_cloud_errors.py
+++ b/tests/test_cloud_errors.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from custom_components.sonoff.core.ewelink import XRegistry
 from custom_components.sonoff.core.ewelink.cloud import cloud_error_event
 
@@ -99,3 +101,24 @@ def test_cloud_context_marks_zbbridge_children_as_cloud_only():
         "bridge_framework": "3.3.0",
         "transport_reason": "zbbridge_child_lan_unsupported",
     }
+
+
+def test_unconfirmed_cloud_warnings_are_coalesced_per_device_and_code():
+    registry = XRegistry(None)
+    device = {"deviceid": "1000123abc", "name": "Test device"}
+    record = {"code": 411, "sequence": "one"}
+
+    with patch(
+        "custom_components.sonoff.core.ewelink._CLOUD_LOGGER.warning"
+    ) as warning:
+        registry.log_unconfirmed_cloud_error(device, record, now=1000)
+        registry.log_unconfirmed_cloud_error(
+            device, {"code": 411, "sequence": "two"}, now=1001
+        )
+        registry.log_unconfirmed_cloud_error(
+            device, {"code": 411, "sequence": "three"}, now=1901
+        )
+
+    assert warning.call_count == 2
+    assert warning.call_args_list[0].args[-1] == 0
+    assert warning.call_args_list[1].args[-1] == 1

--- a/tests/test_cloud_errors.py
+++ b/tests/test_cloud_errors.py
@@ -1,0 +1,101 @@
+from custom_components.sonoff.core.ewelink import XRegistry
+from custom_components.sonoff.core.ewelink.cloud import cloud_error_event
+
+
+def test_cloud_error_event_is_redacted():
+    event = cloud_error_event(
+        {
+            "error": 411,
+            "deviceid": "1000123abc",
+            "sequence": "123",
+            "apikey": "must-not-leak",
+            "uid": "must-not-leak",
+        }
+    )
+
+    assert event == {
+        "error": 411,
+        "deviceid": "1000123abc",
+        "sequence": "123",
+        "action": None,
+    }
+
+
+def test_cloud_error_records_parent_context_without_running_loop():
+    registry = XRegistry(None)
+    parent = {"deviceid": "10022bd4a5", "productModel": "ZBBridge-P"}
+    device = {"deviceid": "1000123abc", "parent": parent}
+    registry.devices = {device["deviceid"]: device}
+    registry.cloud_pending["123"] = {
+        "action": "update",
+        "param_keys": ["switch"],
+        "safe_retry": True,
+        "origin": "command",
+        "transport": "cloud",
+        "transport_reason": "zbbridge_child_lan_unsupported",
+        "device_rssi": -73,
+        "bridge_rssi": -43,
+        "bridge_framework": "3.3.0",
+    }
+
+    registry.cloud_error({"error": 411, "deviceid": device["deviceid"], "sequence": "123"})
+
+    assert device["last_cloud_error"]["code"] == 411
+    assert device["last_cloud_error"]["parent_model"] == "ZBBridge-P"
+    assert device["last_cloud_error"]["param_keys"] == ["switch"]
+    assert device["last_cloud_error"]["transport_reason"] == "zbbridge_child_lan_unsupported"
+    assert device["last_cloud_error"]["device_rssi"] == -73
+    assert device["last_cloud_error"]["bridge_framework"] == "3.3.0"
+
+
+def test_only_explicit_switch_values_are_safe_to_retry():
+    assert XRegistry.is_safe_retry({"switch": "on"})
+    assert XRegistry.is_safe_retry({"switch": "off"})
+    assert not XRegistry.is_safe_retry({"switch": "toggle"})
+    assert not XRegistry.is_safe_retry({"switch": "on", "brightness": 10})
+    assert not XRegistry.is_safe_retry(None)
+
+
+def test_known_switch_state_skips_only_a_redundant_command():
+    device = {"params": {"switch": "off"}}
+
+    assert XRegistry.is_redundant_switch_command(device, {"switch": "off"})
+    assert not XRegistry.is_redundant_switch_command(device, {"switch": "on"})
+    assert not XRegistry.is_redundant_switch_command(device, {"switch": "toggle"})
+    assert not XRegistry.is_redundant_switch_command(
+        device, {"switch": "off", "brightness": 50}
+    )
+
+
+def test_reconciliation_requires_the_matching_response_and_state():
+    command = {"params": {"switch": "on"}}
+    device = {"cloud_seq": "query-1", "params": {"switch": "on"}}
+
+    assert XRegistry.is_command_confirmed(device, command, "query-1")
+    assert not XRegistry.is_command_confirmed(device, command, "query-2")
+
+    device["params"]["switch"] = "off"
+    assert not XRegistry.is_command_confirmed(device, command, "query-1")
+
+
+def test_cloud_context_marks_zbbridge_children_as_cloud_only():
+    context = XRegistry.cloud_context(
+        {
+            "params": {"subDevRssi": -73},
+            "parent": {
+                "deviceid": "10022bd4a5",
+                "productModel": "ZBBridge-P",
+                "params": {"rssi": -43, "hostVersion": "3.3.0"},
+            },
+        }
+    )
+
+    assert context == {
+        "transport": "cloud",
+        "device_rssi": -73,
+        "parentid": "10022bd4a5",
+        "parent_model": "ZBBridge-P",
+        "bridge_rssi": -43,
+        "bridge_framework": "3.3.0",
+        "transport_reason": "zbbridge_child_lan_unsupported",
+    }

--- a/tests/test_diagnostics_redaction.py
+++ b/tests/test_diagnostics_redaction.py
@@ -1,0 +1,39 @@
+from custom_components.sonoff.diagnostics import redact_diagnostics_data
+
+
+def test_diagnostics_redact_credentials_identifiers_and_log_values():
+    appsecret = "a-secret-that-must-never-be-exported"
+    deviceid = "1000abcdef"
+    device_name = "Luce Salotto Andrea"
+    data = {
+        "appid": "private-app-id",
+        "appsecret": appsecret,
+        "deviceid": deviceid,
+        "parentid": "1000parent",
+        "host": "192.168.100.50",
+        "apikey": "private-api-key",
+        "uid": "private-user-id",
+        "sequence": "123456789",
+        "timestamp": 1234567890,
+        "param_keys": ["switch"],
+        "latency_ms": 120,
+        "message": f"device={deviceid} name={device_name} secret={appsecret}",
+    }
+
+    result = redact_diagnostics_data(data, (appsecret, deviceid, device_name))
+
+    for key in (
+        "appid",
+        "appsecret",
+        "deviceid",
+        "parentid",
+        "host",
+        "apikey",
+        "uid",
+        "sequence",
+        "timestamp",
+    ):
+        assert result[key] == "***"
+    assert result["param_keys"] == ["switch"]
+    assert result["latency_ms"] == 120
+    assert result["message"] == "device=*** name=*** secret=***"


### PR DESCRIPTION
Hi AlexxIT,

First of all, thank you for your work on SonoffLAN. It is a very useful component, and this proposal is intended to improve its reliability and troubleshooting capabilities while preserving its existing design.

My name is Andrea. I investigated the intermittent eWeLink cloud error 411 reported in #1533 on my Home Assistant installation, with the assistance of Codex. I have been successfully testing this approach in my fork. During the observation period after removing redundant automatic commands in the installation and applying the cloud handling and diagnostics changes, the recurring 411 errors disappeared. This PR adds an integration-level guard so that the same prevention does not depend only on automation design.

## Observed cause

In my installation, some Zigbee children are connected through a Sonoff ZBBridge-P and therefore use the eWeLink cloud path. I observed that a cloud command can be issued when the integration already knows that the target switch is in the requested state (for example, an `off` request for an already-off device). I also observed closely timed commands for the same device, for example from overlapping Home Assistant automations or a manual command near an automation action.

Those redundant or concurrent cloud requests were the plausible triggering condition for the sporadic 411 responses in this setup. This does not claim that every 411 has the same root cause or that it proves a LAN/Wi-Fi fault; it addresses the command pattern that was reproducibly correlated with the errors here.

## What this PR changes

- Serializes cloud commands per device.
- Re-checks an explicit single `switch: on`/`switch: off` command while holding that lock and skips it if the known device state already matches. This prevents an unnecessary cloud request such as turning an already-off device off again.
- Queues the non-actuating post-command state query before releasing the same device lock, reducing command overlap and improving the state available to the next command.
- Treats an `error: 0` response without `params` as a successful acknowledgement instead of an unknown-response warning.
- Handles 411 and 504 responses with a delayed, non-actuating state reconciliation.
- Adds an opt-in retry, disabled by default, only for an unconfirmed and idempotent single `switch: on` or `switch: off` command. It never retries toggles, scenes, multi-parameter commands, or other non-idempotent actuator commands.
- Adds bounded command-error diagnostics with transport, parameter names, latency, parent model, bridge firmware and RSSI context.
- Redacts exported diagnostics explicitly: app/cloud credentials, device and bridge identifiers, sequence values, device names, local IP/network addresses, and the same values embedded in diagnostic copies of system-log messages. Local logs remain useful, while downloadable diagnostics are safe to attach to a public issue.
- Adds tests for safe retry eligibility, redundant-command detection, reconciliation, ZBBridge-P context, and diagnostics redaction.

## Validation

- `python -m pytest -q --capture=no tests/test_cloud_errors.py tests/test_diagnostics_redaction.py`
- Result: 7 passed.

No personal Home Assistant configuration, credentials, devices, or automations are included in this PR.

Thanks again for maintaining SonoffLAN. I hope this can help improve the component's effectiveness for users who encounter ambiguous cloud command responses.
