### PR TITLE
Fix concentration unit deprecation warnings

### DIFF
--- a/custom_components/sonoff/sensor.py
+++ b/custom_components/sonoff/sensor.py
@@ -8,6 +8,8 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
+    MAJOR_VERSION,
+    MINOR_VERSION,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     UnitOfElectricCurrent,
@@ -19,22 +21,20 @@ from homeassistant.const import (
 )
 from homeassistant.util import dt
 
-try:
-    from homeassistant.const import UnitOfDensity, UnitOfRatio
-except ImportError:
-    from homeassistant.const import (
-        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER as MICROGRAMS_PER_CUBIC_METER,
-        CONCENTRATION_PARTS_PER_MILLION as PARTS_PER_MILLION,
-    )
-else:
-    MICROGRAMS_PER_CUBIC_METER = UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
-    PARTS_PER_MILLION = UnitOfRatio.PARTS_PER_MILLION
-
 from .core.const import DOMAIN
 from .core.entity import XEntity
 from .core.ewelink import SIGNAL_ADD_ENTITIES, XRegistry
 
 PARALLEL_UPDATES = 0  # fix entity_platform parallel_updates Semaphore
+
+if (MAJOR_VERSION, MINOR_VERSION) >= (2026, 7):
+    from homeassistant.const import UnitOfDensity, UnitOfRatio
+
+    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER = UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
+    CONCENTRATION_PARTS_PER_MILLION = UnitOfRatio.PARTS_PER_MILLION
+else:
+    from homeassistant.const import CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+    from homeassistant.const import CONCENTRATION_PARTS_PER_MILLION
 
 
 async def async_setup_entry(hass, config_entry, add_entities):
@@ -67,7 +67,7 @@ DEVICE_CLASSES = {
 UNITS = {
     "battery": PERCENTAGE,
     "battery_voltage": UnitOfElectricPotential.VOLT,
-    "co2": PARTS_PER_MILLION,
+    "co2": CONCENTRATION_PARTS_PER_MILLION,
     "cpu_temperature": UnitOfTemperature.CELSIUS,
     "current": UnitOfElectricCurrent.AMPERE,
     "current_supply": UnitOfElectricCurrent.AMPERE,
@@ -75,8 +75,8 @@ UNITS = {
     "outdoor_temp": UnitOfTemperature.CELSIUS,
     "power": UnitOfPower.WATT,
     "power_supply": UnitOfPower.WATT,
-    "pm25": MICROGRAMS_PER_CUBIC_METER,
-    "pm10": MICROGRAMS_PER_CUBIC_METER,
+    "pm25": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "pm10": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     "remote_temperature": UnitOfTemperature.CELSIUS,
     "rssi": SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     "temperature": UnitOfTemperature.CELSIUS,

--- a/custom_components/sonoff/sensor.py
+++ b/custom_components/sonoff/sensor.py
@@ -8,8 +8,6 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     UnitOfElectricCurrent,
@@ -20,6 +18,17 @@ from homeassistant.const import (
     UnitOfVolume,
 )
 from homeassistant.util import dt
+
+try:
+    from homeassistant.const import UnitOfDensity, UnitOfRatio
+except ImportError:
+    from homeassistant.const import (
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER as MICROGRAMS_PER_CUBIC_METER,
+        CONCENTRATION_PARTS_PER_MILLION as PARTS_PER_MILLION,
+    )
+else:
+    MICROGRAMS_PER_CUBIC_METER = UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
+    PARTS_PER_MILLION = UnitOfRatio.PARTS_PER_MILLION
 
 from .core.const import DOMAIN
 from .core.entity import XEntity
@@ -58,7 +67,7 @@ DEVICE_CLASSES = {
 UNITS = {
     "battery": PERCENTAGE,
     "battery_voltage": UnitOfElectricPotential.VOLT,
-    "co2": CONCENTRATION_PARTS_PER_MILLION,
+    "co2": PARTS_PER_MILLION,
     "cpu_temperature": UnitOfTemperature.CELSIUS,
     "current": UnitOfElectricCurrent.AMPERE,
     "current_supply": UnitOfElectricCurrent.AMPERE,
@@ -66,8 +75,8 @@ UNITS = {
     "outdoor_temp": UnitOfTemperature.CELSIUS,
     "power": UnitOfPower.WATT,
     "power_supply": UnitOfPower.WATT,
-    "pm25": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    "pm10": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "pm25": MICROGRAMS_PER_CUBIC_METER,
+    "pm10": MICROGRAMS_PER_CUBIC_METER,
     "remote_temperature": UnitOfTemperature.CELSIUS,
     "rssi": SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     "temperature": UnitOfTemperature.CELSIUS,

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -12,7 +12,6 @@ from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.components.script import ATTR_LAST_TRIGGERED
 from homeassistant.const import (
-    CONCENTRATION_PARTS_PER_MILLION,
     MAJOR_VERSION,
     MINOR_VERSION,
     STATE_ON,
@@ -54,6 +53,7 @@ from custom_components.sonoff.light import (
 from custom_components.sonoff.number import XNumber, XPulseWidth
 from custom_components.sonoff.select import XSelectStartup
 from custom_components.sonoff.sensor import (
+    PARTS_PER_MILLION,
     XButtonKey,
     XButtonLocalKey,
     XCloudEnergyDualR3,
@@ -2664,7 +2664,7 @@ def test_sawf_08p():
     assert co2.name == "Device1 CO2"
     assert co2.state == 510
     assert co2.device_class == SensorDeviceClass.CO2
-    assert co2.native_unit_of_measurement == CONCENTRATION_PARTS_PER_MILLION
+    assert co2.native_unit_of_measurement == PARTS_PER_MILLION
     assert co2.state_class == SensorStateClass.MEASUREMENT
 
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -53,7 +53,7 @@ from custom_components.sonoff.light import (
 from custom_components.sonoff.number import XNumber, XPulseWidth
 from custom_components.sonoff.select import XSelectStartup
 from custom_components.sonoff.sensor import (
-    PARTS_PER_MILLION,
+    CONCENTRATION_PARTS_PER_MILLION,
     XButtonKey,
     XButtonLocalKey,
     XCloudEnergyDualR3,
@@ -2664,7 +2664,7 @@ def test_sawf_08p():
     assert co2.name == "Device1 CO2"
     assert co2.state == 510
     assert co2.device_class == SensorDeviceClass.CO2
-    assert co2.native_unit_of_measurement == PARTS_PER_MILLION
+    assert co2.native_unit_of_measurement == CONCENTRATION_PARTS_PER_MILLION
     assert co2.state_class == SensorStateClass.MEASUREMENT
 
 


### PR DESCRIPTION
## Summary

- use `UnitOfDensity` and `UnitOfRatio` when Home Assistant provides them
- retain compatibility with the declared Home Assistant 2023.2 minimum by falling back to the legacy concentration constants
- update the CO2 unit test to use the compatibility value without importing a deprecated constant

## Root cause

Home Assistant 2026.8 warns when integrations import `CONCENTRATION_MICROGRAMS_PER_CUBIC_METER` or `CONCENTRATION_PARTS_PER_MILLION`. Their replacements were introduced in Home Assistant 2026.7, while SonoffLAN still declares and enforces Home Assistant 2023.2 as its minimum version.

The feature-detection shim avoids touching the deprecated constants on current Home Assistant versions without dropping support for older installations.

Fixes #1849.

## Validation

- full test suite on Home Assistant 2026.8.0b2 / Python 3.14: 94 passed
- fresh Sonoff sensor import on Home Assistant 2026.8.0b2 with no concentration deprecation warning
- legacy and current import paths exercised independently
- changed files parsed successfully using the Python 3.10 grammar required by Home Assistant 2023.2
