### PR TITLE
Update minimum Home Assistant version

### DIFF
--- a/custom_components/sonoff/__init__.py
+++ b/custom_components/sonoff/__init__.py
@@ -102,7 +102,7 @@ UNIQUE_DEVICES = {}
 
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
-    if (MAJOR_VERSION, MINOR_VERSION) < (2023, 2):
+    if (MAJOR_VERSION, MINOR_VERSION) < (2025, 6):
         raise Exception("unsupported hass version")
 
     # init storage for registries

--- a/custom_components/sonoff/alarm_control_panel.py
+++ b/custom_components/sonoff/alarm_control_panel.py
@@ -1,8 +1,8 @@
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
     AlarmControlPanelEntityFeature,
+    AlarmControlPanelState,
 )
-from homeassistant.const import MAJOR_VERSION, MINOR_VERSION
 
 from .core.const import DOMAIN
 from .core.entity import XEntity
@@ -21,28 +21,18 @@ async def async_setup_entry(hass, config_entry, add_entities):
     )
 
 
-if (MAJOR_VERSION, MINOR_VERSION) >= (2024, 11):
-    from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+STATES = {
+    0: AlarmControlPanelState.DISARMED,
+    1: AlarmControlPanelState.ARMED_HOME,
+    2: AlarmControlPanelState.ARMED_AWAY,
+    3: AlarmControlPanelState.ARMED_NIGHT,
+}
 
-    STATES = {
-        0: AlarmControlPanelState.DISARMED,
-        1: AlarmControlPanelState.ARMED_HOME,
-        2: AlarmControlPanelState.ARMED_AWAY,
-        3: AlarmControlPanelState.ARMED_NIGHT,
-    }
 
-    class XAlarmControlBase(XEntity, AlarmControlPanelEntity):
-        def set_state(self, params: dict):
-            if self.param in params:
-                self._attr_alarm_state = STATES.get(params[self.param])
-
-else:
-    STATES = {0: "disarmed", 1: "armed_home", 2: "armed_away", 3: "armed_night"}
-
-    class XAlarmControlBase(XEntity, AlarmControlPanelEntity):
-        def set_state(self, params: dict):
-            if self.param in params:
-                self._attr_state = STATES.get(params[self.param])
+class XAlarmControlBase(XEntity, AlarmControlPanelEntity):
+    def set_state(self, params: dict):
+        if self.param in params:
+            self._attr_alarm_state = STATES.get(params[self.param])
 
 
 class XPanelAlarm(XAlarmControlBase):

--- a/custom_components/sonoff/climate.py
+++ b/custom_components/sonoff/climate.py
@@ -4,7 +4,7 @@ from homeassistant.components.climate.const import (
     HVACMode,
     HVACAction,
 )
-from homeassistant.const import MAJOR_VERSION, MINOR_VERSION, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 
 from .core.const import DOMAIN
 from .core.entity import XEntity
@@ -36,16 +36,12 @@ class XClimateTH(XEntity, ClimateEntity):
     _attr_target_temperature_step = 1
     _heat_mode_flag = False
 
-    # https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded
-    if (MAJOR_VERSION, MINOR_VERSION) >= (2024, 2):
-        _attr_supported_features = (
-            ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
-            | ClimateEntityFeature.TURN_ON
-            | ClimateEntityFeature.TURN_OFF
-        )
-        _enable_turn_on_off_backwards_compatibility = False
-    else:
-        _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+    )
+    _enable_turn_on_off_backwards_compatibility = False
 
     heat: bool = None
 
@@ -157,16 +153,12 @@ class XClimateNS(XEntity, ClimateEntity):
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 0.5
 
-    # https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded
-    if (MAJOR_VERSION, MINOR_VERSION) >= (2024, 2):
-        _attr_supported_features = (
-            ClimateEntityFeature.TARGET_TEMPERATURE
-            | ClimateEntityFeature.TURN_ON
-            | ClimateEntityFeature.TURN_OFF
-        )
-        _enable_turn_on_off_backwards_compatibility = False
-    else:
-        _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+    )
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(self, ewelink, device: dict):
         # copy mutable list so each instance has its own hvac_modes
@@ -258,19 +250,13 @@ class XThermostat(XEntity, ClimateEntity):
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 0.5
 
-    # https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded
-    if (MAJOR_VERSION, MINOR_VERSION) >= (2024, 2):
-        _attr_supported_features = (
-            ClimateEntityFeature.TARGET_TEMPERATURE
-            | ClimateEntityFeature.PRESET_MODE
-            | ClimateEntityFeature.TURN_ON
-            | ClimateEntityFeature.TURN_OFF
-        )
-        _enable_turn_on_off_backwards_compatibility = False
-    else:
-        _attr_supported_features = (
-            ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
-        )
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.PRESET_MODE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+    )
+    _enable_turn_on_off_backwards_compatibility = False
 
     def set_state(self, params: dict):
         cache = self.device["params"]
@@ -342,18 +328,12 @@ class XThermostatTRVZB(XEntity, ClimateEntity):
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 0.5
 
-    # https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded
-    if (MAJOR_VERSION, MINOR_VERSION) >= (2024, 2):
-        _attr_supported_features = (
-            ClimateEntityFeature.TARGET_TEMPERATURE
-            | ClimateEntityFeature.TURN_ON
-            | ClimateEntityFeature.TURN_OFF
-        )
-        _enable_turn_on_off_backwards_compatibility = False
-    else:
-        _attr_supported_features = (
-            ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.PRESET_MODE
-        )
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+    )
+    _enable_turn_on_off_backwards_compatibility = False
 
     def set_state(self, params: dict):
         cache = self.device["params"]

--- a/custom_components/sonoff/fan.py
+++ b/custom_components/sonoff/fan.py
@@ -2,7 +2,6 @@ from homeassistant.components.fan import (
     FanEntity,
     FanEntityFeature,
 )
-from homeassistant.const import MAJOR_VERSION, MINOR_VERSION
 
 from .core.const import DOMAIN
 from .core.entity import XEntity
@@ -31,15 +30,11 @@ class XFan(XEntity, FanEntity):
     params = {"switches", "fan"}
     _attr_speed_count = 3
 
-    # https://developers.home-assistant.io/blog/2024/07/19/fan-fanentityfeatures-turn-on_off/
-    if (MAJOR_VERSION, MINOR_VERSION) >= (2024, 8):
-        _attr_supported_features = (
-            FanEntityFeature.SET_SPEED
-            | FanEntityFeature.TURN_OFF
-            | FanEntityFeature.TURN_ON
-        )
-    else:
-        _attr_supported_features = FanEntityFeature.SET_SPEED
+    _attr_supported_features = (
+        FanEntityFeature.SET_SPEED
+        | FanEntityFeature.TURN_OFF
+        | FanEntityFeature.TURN_ON
+    )
 
     def __init__(self, ewelink: XRegistry, device: XDevice) -> None:
         super().__init__(ewelink, device)
@@ -176,8 +171,7 @@ class XFanDualR3(XFan):
 
 # noinspection PyAbstractClass
 class XToggleFan(XEntity, FanEntity):
-    if (MAJOR_VERSION, MINOR_VERSION) >= (2024, 8):
-        _attr_supported_features = FanEntityFeature.TURN_OFF | FanEntityFeature.TURN_ON
+    _attr_supported_features = FanEntityFeature.TURN_OFF | FanEntityFeature.TURN_ON
 
     @property
     def is_on(self):

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
     "name": "Sonoff LAN",
-    "homeassistant": "2023.2.0",
+    "homeassistant": "2025.6.0",
     "render_readme": true
 }

--- a/tests/test_backward.py
+++ b/tests/test_backward.py
@@ -18,9 +18,9 @@ from . import init
 
 
 def test_backward():
-    # https://github.com/home-assistant/core/blob/2023.2.0/homeassistant/const.py
-    assert (MAJOR_VERSION, MINOR_VERSION) >= (2023, 2)
-    assert REQUIRED_PYTHON_VER >= (3, 10, 0)
+    # https://github.com/home-assistant/core/blob/2025.6.0/homeassistant/const.py
+    assert (MAJOR_VERSION, MINOR_VERSION) >= (2025, 6)
+    assert REQUIRED_PYTHON_VER >= (3, 13, 2)
 
     assert async_setup_entry
     assert async_get_config_entry_diagnostics
@@ -53,29 +53,19 @@ def test_2024_1_cached_properties():
 def test_2024_2_climate():
     _, entities = init({"extra": {"uiid": 15}})
     climate: ClimateEntity = next(e for e in entities if isinstance(e, XClimateTH))
-    if (MAJOR_VERSION, MINOR_VERSION) >= (2024, 2):
-        assert climate.supported_features == (
-            ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
-            | ClimateEntityFeature.TURN_ON
-            | ClimateEntityFeature.TURN_OFF
-        )
-    else:
-        assert (
-            climate.supported_features == ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
-        )
+    assert climate.supported_features == (
+        ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+    )
 
 
 def test_2024_8_fan():
     _, entities = init({"extra": {"uiid": 34}})
     fan: FanEntity = next(e for e in entities if isinstance(e, XFan))
-    if (MAJOR_VERSION, MINOR_VERSION) >= (2024, 8):
-        assert fan.supported_features == (
-            FanEntityFeature.SET_SPEED
-            | FanEntityFeature.PRESET_MODE
-            | FanEntityFeature.TURN_OFF
-            | FanEntityFeature.TURN_ON
-        )
-    else:
-        assert fan.supported_features == (
-            FanEntityFeature.SET_SPEED | FanEntityFeature.PRESET_MODE
-        )
+    assert fan.supported_features == (
+        FanEntityFeature.SET_SPEED
+        | FanEntityFeature.PRESET_MODE
+        | FanEntityFeature.TURN_OFF
+        | FanEntityFeature.TURN_ON
+    )


### PR DESCRIPTION
## Summary

Update the declared and enforced minimum Home Assistant version from 2023.2 to 2025.6, and remove version branches that can no longer be reached.

## Why 2025.6?

The current `2023.2.0` declaration no longer matches the APIs used by the integration:

- `XFan17` unconditionally uses `FanEntityFeature.TURN_ON` and `TURN_OFF`. Home Assistant [introduced those flags in 2024.8](https://developers.home-assistant.io/blog/2024/07/19/fan-fanentityfeatures-turn-on_off/).
- More importantly, the test suite exposes a concrete runtime incompatibility with Home Assistant 2025.5. In that release, [`SelectEntity._attr_current_option` is only annotated](https://github.com/home-assistant/core/blob/2025.5.0/homeassistant/components/select/__init__.py#L123-L165), without a default. `XStartup` does not set the attribute when a device does not report `startup`, so writing its initial state raises:

  ```text
  AttributeError: 'XStartup' object has no attribute '__attr_current_option'
  ```

- Home Assistant 2025.6 [sets `_attr_current_option` to `None`](https://github.com/home-assistant/core/blob/2025.6.0/homeassistant/components/select/__init__.py#L123-L165), and the complete SonoffLAN suite passes without a compatibility patch. Home Assistant 2025.6 also [requires Python 3.13.2](https://github.com/home-assistant/core/blob/2025.6.0/homeassistant/const.py#L39-L49), which is reflected in the backward-compatibility test.

This makes 2025.6 the first Home Assistant release that satisfies the current code and test suite as-is. It is also more than a year old at the time of this change, so adding another shim solely for 2025.5 and older would preserve an already stale compatibility target instead of documenting the integration's real lower bound.

## Changes

- Set the HACS minimum and runtime guard to Home Assistant 2025.6.
- Update the backward-compatibility assertions for Home Assistant and Python.
- Remove unreachable compatibility branches for:
  - climate feature flags before Home Assistant 2024.2;
  - fan feature flags before Home Assistant 2024.8;
  - the alarm control panel state API before Home Assistant 2024.11.

## Validation

- Home Assistant 2025.5.0, excluding the intentional minimum-version assertion: fails in `test_pow2_energy` with the `XStartup._attr_current_option` `AttributeError` above.
- Home Assistant 2025.6.0: **94 passed**.
- Current Home Assistant beta: **94 passed**.

This PR is intentionally separate from #1850 and does not change concentration-unit compatibility.
