### PR TITLE
Bound Sonoff debug logging

### DIFF
--- a/custom_components/sonoff/system_health.py
+++ b/custom_components/sonoff/system_health.py
@@ -69,6 +69,16 @@ async def setup_debug(hass: HomeAssistant, logger: Logger):
     integration.__dict__.pop("manifest_json_fragment", None)  # drop cached_property
 
 
+class WarningPassthrough(logging.Handler):
+    """Forward actionable records to Home Assistant's root handlers."""
+
+    def __init__(self):
+        super().__init__(logging.WARNING)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        logging.getLogger().handle(record)
+
+
 class DebugView(logging.Handler, HomeAssistantView):
     """Class generate web page with component debug logs."""
 
@@ -81,13 +91,17 @@ class DebugView(logging.Handler, HomeAssistantView):
         # https://waymoot.org/home/python_string/
         self.text = deque(maxlen=10000)
 
-        self.propagate_level = logger.getEffectiveLevel()
-
         # random url because without authorization!!!
         DebugView.url = f"/api/{DOMAIN}/{uuid.uuid4()}"
 
         logger.addHandler(self)
+        self.warning_passthrough = WarningPassthrough()
+        logger.addHandler(self.warning_passthrough)
         logger.setLevel(logging.DEBUG)
+        # Keep the optional protocol trace in the bounded debug page instead of
+        # forwarding every packet into Home Assistant's raw log stream. Warnings
+        # and errors are still forwarded through WarningPassthrough.
+        logger.propagate = False
 
     def handle(self, rec: logging.LogRecord):
         if isinstance(rec.args, dict):
@@ -100,10 +114,6 @@ class DebugView(logging.Handler, HomeAssistantView):
             exc = traceback.format_exception(*rec.exc_info, limit=1)
             msg += "|" + "".join(exc[-2:]).replace("\n", "|")
         self.text.append(msg)
-
-        # prevent debug to Hass log if user don't want it
-        if self.propagate_level > rec.levelno:
-            rec.levelno = -1
 
     async def get(self, request: web.Request):
         try:

--- a/tests/test_backward.py
+++ b/tests/test_backward.py
@@ -1,3 +1,5 @@
+import logging
+
 from homeassistant.const import REQUIRED_PYTHON_VER
 
 from custom_components.sonoff import *
@@ -38,6 +40,38 @@ def test_backward():
     assert XRemote
     assert XSensor
     assert XSwitch
+
+
+def test_debug_view_keeps_protocol_debug_out_of_root_logs():
+    logger = logging.getLogger("sonoff_test_debug_view")
+    root = logging.getLogger()
+    capture = _CaptureLogHandler()
+    old_level, old_propagate = logger.level, logger.propagate
+    root.addHandler(capture)
+    try:
+        view = DebugView(logger)
+        logger.debug("protocol trace")
+        logger.warning("actionable warning")
+
+        assert any("protocol trace" in line for line in view.text)
+        assert [record.getMessage() for record in capture.records] == [
+            "actionable warning"
+        ]
+    finally:
+        logger.removeHandler(view)
+        logger.removeHandler(view.warning_passthrough)
+        logger.setLevel(old_level)
+        logger.propagate = old_propagate
+        root.removeHandler(capture)
+
+
+class _CaptureLogHandler(logging.Handler):
+    def __init__(self):
+        super().__init__(logging.DEBUG)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
 
 
 def test_2024_1_cached_properties():


### PR DESCRIPTION
## Summary

The optional Sonoff debug view currently raises the integration logger to `DEBUG` and lets the protocol logger propagate to Home Assistant's raw log stream. Long-running debug mode can therefore write high-frequency Cloud/Local protocol traces to Home Assistant logs and, when configured, associated system-log/recorder processing.

This change keeps the existing bounded in-memory debug page while preventing protocol `DEBUG` records from propagating to Home Assistant's root handlers. `WARNING` and `ERROR` records are still explicitly forwarded, so actionable failures remain visible.

## Changes

- Add a warning/error passthrough handler for the Sonoff logger.
- Disable propagation after attaching the optional debug view.
- Stop mutating `LogRecord.levelno` as a side effect of debug capture.
- Add regression coverage proving that a protocol debug trace stays in the view while an actionable warning reaches the root logger.

## Impact

This makes temporary debugging safer for production Home Assistant installations: diagnostics remain available at the random debug-view URL, but protocol traffic no longer grows the raw log stream continuously.

## Validation

- `python3 -m compileall -q custom_components tests`
- `git diff --check`

The regression test is included; the local environment used for this contribution does not have the project's pytest/Home Assistant test dependencies installed.

No configuration, credentials, device identifiers, or private-network information are included.