### PR TITLE
Add inching settings for Sonoff POWR2

### DIFF
--- a/custom_components/sonoff/core/devices.py
+++ b/custom_components/sonoff/core/devices.py
@@ -261,6 +261,8 @@ DEVICES = {
         XSwitch,
         LED,
         RSSI,
+        PULSE,
+        XPulseWidth,
         spec(XSensor, param="current"),
         spec(XSensor, param="power"),
         spec(XSensor, param="voltage"),

--- a/custom_components/sonoff/number.py
+++ b/custom_components/sonoff/number.py
@@ -39,7 +39,7 @@ class XNumber(XEntity, NumberEntity):
 class XPulseWidth(XNumber):
     param = "pulseWidth"
 
-    _attr_device_class = NumberDeviceClass.DURATION
+    _attr_device_class = getattr(NumberDeviceClass, "DURATION")  # backward support
     _attr_entity_registry_enabled_default = False
 
     _attr_native_max_value = 36000

--- a/custom_components/sonoff/number.py
+++ b/custom_components/sonoff/number.py
@@ -1,5 +1,5 @@
-from homeassistant.components.number import NumberEntity, NumberMode
-from homeassistant.const import UnitOfTemperature
+from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
+from homeassistant.const import UnitOfTemperature, UnitOfTime
 
 from .core.const import DOMAIN
 from .core.entity import XEntity
@@ -39,11 +39,13 @@ class XNumber(XEntity, NumberEntity):
 class XPulseWidth(XNumber):
     param = "pulseWidth"
 
+    _attr_device_class = NumberDeviceClass.DURATION
     _attr_entity_registry_enabled_default = False
 
     _attr_native_max_value = 36000
     _attr_native_min_value = 0.5
     _attr_native_step = 0.5
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
 
     def set_state(self, params: dict):
         self._attr_native_value = params["pulseWidth"] / 1000

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -574,7 +574,7 @@ def test_sonoff_pow():
 
     pulse_width = next(e for e in entities if isinstance(e, XPulseWidth))
     assert pulse_width.native_value == 0.5
-    assert pulse_width.device_class == NumberDeviceClass.DURATION
+    assert pulse_width.device_class == getattr(NumberDeviceClass, "DURATION")
     assert pulse_width.native_unit_of_measurement == UnitOfTime.SECONDS
     assert pulse_width.entity_registry_enabled_default is False
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -8,6 +8,7 @@ from homeassistant.components.light import (
     ColorMode,
     LightEntity,
 )
+from homeassistant.components.number import NumberDeviceClass
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.components.script import ATTR_LAST_TRIGGERED
@@ -17,6 +18,7 @@ from homeassistant.const import (
     MINOR_VERSION,
     STATE_ON,
     UnitOfEnergy,
+    UnitOfTime,
     UnitOfVolume,
 )
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
@@ -565,6 +567,16 @@ def test_sonoff_pow():
     assert power.state == 12.34
     power: XSensor = next(e for e in entities if e.uid == "current")
     assert power.state == 1.23
+
+    pulse: XToggle = next(e for e in entities if e.uid == "pulse")
+    assert pulse.is_on is False
+    assert pulse.entity_registry_enabled_default is False
+
+    pulse_width = next(e for e in entities if isinstance(e, XPulseWidth))
+    assert pulse_width.native_value == 0.5
+    assert pulse_width.device_class == NumberDeviceClass.DURATION
+    assert pulse_width.native_unit_of_measurement == UnitOfTime.SECONDS
+    assert pulse_width.entity_registry_enabled_default is False
 
 
 def test_rfbridge():


### PR DESCRIPTION
## Summary

- expose the existing `PULSE` and `XPulseWidth` entities for Sonoff POWR2 devices with UIID 32
- declare the pulse width as a duration measured in seconds
- add coverage for the new entities to the existing POWR2 test

## Background

UIID 32 devices report the `pulse` and `pulseWidth` parameters, but the SonoffLAN device specification does not include the existing entities that expose them.

As a result, Home Assistant receives the inching configuration but does not show it on the device page.

The pulse-width entity already converts the device value from milliseconds to seconds. This change adds the corresponding Home Assistant duration metadata and unit of measurement.

Both entities remain disabled by default, consistent with the existing inching entities used by other supported device types.

## Testing

- 94 tests passed
- tested with Home Assistant 2026.7.4 and Python 3.14.6
- manually verified on a PSF-X67 device with UIID 32


<img width="420" height="359" alt="image" src="https://github.com/user-attachments/assets/a6392df5-4b08-45e7-b9a3-93b26ce01f0e" />
