### PR TITLE
Add support for SNZB-09P indoor siren (uiid 7056)

### DIFF
--- a/custom_components/sonoff/binary_sensor.py
+++ b/custom_components/sonoff/binary_sensor.py
@@ -98,6 +98,18 @@ class XWaterSensor(XEntity, BinarySensorEntity):
         self._attr_is_on = params[self.param] == 1
 
 
+class XExternalPower(XEntity, BinarySensorEntity):
+    """SNZB-09P (uiid 7056) - whether it's on external/mains power."""
+
+    param = "powerExternalState"
+    uid = "external_power"
+    _attr_device_class = BinarySensorDeviceClass.PLUG
+    _attr_entity_registry_enabled_default = False
+
+    def set_state(self, params: dict):
+        self._attr_is_on = params["powerExternalState"] == "on"
+
+
 # noinspection PyAbstractClass
 class XRemoteSensor(BinarySensorEntity, RestoreEntity):
     _attr_is_on = False

--- a/custom_components/sonoff/binary_sensor.py
+++ b/custom_components/sonoff/binary_sensor.py
@@ -98,7 +98,7 @@ class XWaterSensor(XEntity, BinarySensorEntity):
         self._attr_is_on = params[self.param] == 1
 
 
-class XExternalPower(XEntity, BinarySensorEntity):
+class XAlarmPower(XEntity, BinarySensorEntity):
     """SNZB-09P (uiid 7056) - whether it's on external/mains power."""
 
     param = "powerExternalState"

--- a/custom_components/sonoff/button.py
+++ b/custom_components/sonoff/button.py
@@ -67,3 +67,20 @@ class XT5Effect(XEntity, ButtonEntity):
     async def async_press(self):
         if pre := self.device["params"].get("preEffects"):
             await self.ewelink.send(self.device, {"preEffects": pre})
+
+
+class XAlarmButton(XEntity, ButtonEntity):
+    """SNZB-09P (uiid 7056) - triggers the siren (confirmed working).
+
+    Sends `alarmSetting.test = true`. The device turns it back off on its
+    own once the configured Alarm Duration elapses, so no reset is sent.
+    """
+
+    params = {"alarmSetting"}
+    uid = "allarme"
+    _attr_icon = "mdi:bullhorn"
+
+    async def async_press(self):
+        setting = dict(self.device["params"].get("alarmSetting", {}))
+        setting["test"] = True
+        await self.ewelink.send(self.device, {"alarmSetting": setting})

--- a/custom_components/sonoff/core/devices.py
+++ b/custom_components/sonoff/core/devices.py
@@ -20,8 +20,8 @@ from homeassistant.components.switch import SwitchEntity
 from .ewelink import XDevice
 from ..alarm_control_panel import XPanelAlarm
 from ..binary_sensor import (
+    XAlarmPower,
     XBinarySensor,
-    XExternalPower,
     XHumanSensor,
     XLightSensor,
     XWaterSensor,
@@ -778,7 +778,7 @@ DEVICES = {
         XAlarmVolume,
         XAlarmSoundType,
         spec(XSensor, param="alarmType", uid="alarm_status"),
-        XExternalPower,
+        XAlarmPower,
         Battery,
         ZRSSI,
     ],

--- a/custom_components/sonoff/core/devices.py
+++ b/custom_components/sonoff/core/devices.py
@@ -21,13 +21,14 @@ from .ewelink import XDevice
 from ..alarm_control_panel import XPanelAlarm
 from ..binary_sensor import (
     XBinarySensor,
+    XExternalPower,
     XHumanSensor,
     XLightSensor,
     XWaterSensor,
     XWiFiDoor,
     XZigbeeMotion,
 )
-from ..button import XButton, XT5Effect
+from ..button import XAlarmButton, XButton, XT5Effect
 from ..climate import XClimateNS, XClimateTH, XThermostat, XThermostatTRVZB
 from ..core.entity import XEntity
 from ..cover import XCover, XCoverDualR3, XCoverOP, XCoverT5, XZBCover, XZigbeeCover
@@ -54,10 +55,17 @@ from ..light import (
     XZigbeeLight,
 )
 from ..media_player import XPanelBuzzer
-from ..number import XPulseWidth, XSensitivity, XTempCorrectionNumber
+from ..number import (
+    XAlarmDuration,
+    XAlarmVolume,
+    XPulseWidth,
+    XSensitivity,
+    XTempCorrectionNumber,
+)
 from ..remote import XRemote
 from ..select import XSelectStartup, XStartup
 from ..sensor import (
+    XAlarmSoundType,
     XButtonKey,
     XButtonLocalKey,
     XCPUTemperature,
@@ -79,6 +87,8 @@ from ..sensor import (
     XWiFiDoorBattery,
 )
 from ..switch import (
+    XAlarmLight,
+    XAlarmVoice,
     XBoolSwitch,
     XIntSwitch,
     XPanelScreen,
@@ -759,6 +769,19 @@ DEVICES = {
     7047: [spec(XBoolSwitch, param="switch_00", uid="switch"), Battery, ZRSSI],
     # SNZB-03PR2 https://github.com/AlexxIT/SonoffLAN/issues/1824
     7055: [XHumanSensor, spec(XSensor, param="illumination"), Battery, ZRSSI],
+    # SNZB-09P (Indoor Siren)
+    7056: [
+        XAlarmButton,
+        XAlarmVoice,
+        XAlarmLight,
+        XAlarmDuration,
+        XAlarmVolume,
+        XAlarmSoundType,
+        spec(XSensor, param="alarmType", uid="alarm_status"),
+        XExternalPower,
+        Battery,
+        ZRSSI,
+    ],
 }
 
 

--- a/custom_components/sonoff/number.py
+++ b/custom_components/sonoff/number.py
@@ -78,3 +78,44 @@ class XSensitivity(XNumber):
     _attr_entity_registry_enabled_default = False
     _attr_native_max_value = 3
     _attr_native_min_value = 1
+
+
+# noinspection PyAbstractClass
+class XAlarmSettingNumber(XEntity, NumberEntity):
+    """Base class for SNZB-09P (uiid 7056) numbers nested inside `alarmSetting`.
+
+    See XAlarmSettingSwitch in switch.py for details - values reverse
+    engineered from device diagnostics, not official docs.
+    """
+
+    params = {"alarmSetting"}
+    field: str = None
+
+    def set_state(self, params: dict):
+        self._attr_native_value = params.get("alarmSetting", {}).get(self.field, 0)
+
+    async def async_set_native_value(self, value: float) -> None:
+        setting = dict(self.device["params"].get("alarmSetting", {}))
+        setting[self.field] = int(value)
+        await self.ewelink.send(self.device, {"alarmSetting": setting})
+
+
+class XAlarmDuration(XAlarmSettingNumber):
+    field = "duration"
+    uid = "alarm_duration"
+
+    _attr_native_min_value = 1
+    _attr_native_max_value = 180
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = "s"
+
+
+class XAlarmVolume(XAlarmSettingNumber):
+    """Guessed range 0-3 (app showed 'LOW') - verify on your own device."""
+
+    field = "volume"
+    uid = "alarm_volume"
+
+    _attr_native_min_value = 0
+    _attr_native_max_value = 3
+    _attr_native_step = 1

--- a/custom_components/sonoff/sensor.py
+++ b/custom_components/sonoff/sensor.py
@@ -477,6 +477,22 @@ class XT5Action(XEventSesor):
             asyncio.create_task(self.clear_state())
 
 
+class XAlarmSoundType(XEntity, SensorEntity):
+    """SNZB-09P (uiid 7056) - read-only, value nested inside `alarmSetting`.
+
+    Kept read-only (rather than a select) because the full list of valid
+    `alertSound` values is unknown - only "alarm0" has been observed.
+    """
+
+    params = {"alarmSetting"}
+    uid = "alarm_sound_type"
+
+    _attr_entity_registry_enabled_default = False
+
+    def set_state(self, params: dict):
+        self._attr_native_value = params.get("alarmSetting", {}).get("alertSound")
+
+
 class XUnknown(XEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.TIMESTAMP
 

--- a/custom_components/sonoff/switch.py
+++ b/custom_components/sonoff/switch.py
@@ -169,3 +169,45 @@ class XPanelScreen(XEntity, SwitchEntity):
 
     async def async_turn_off(self):
         await self.ewelink.send(self.device, {"openLED": False})
+
+
+# noinspection PyAbstractClass
+class XAlarmSettingSwitch(XEntity, SwitchEntity):
+    """Base class for SNZB-09P (uiid 7056) switches nested inside `alarmSetting`.
+
+    eWeLink sends/expects this device's config as a single nested dict:
+      "alarmSetting": {"duration": 10, "test": false, "alertSound": "alarm0",
+                        "voice": true, "volume": 0, "light": true}
+
+    Reverse engineered from device diagnostics - not from official docs, so
+    double-check behaviour on your own device.
+    """
+
+    params = {"alarmSetting"}
+    field: str = None
+
+    def set_state(self, params: dict):
+        self._attr_is_on = bool(params.get("alarmSetting", {}).get(self.field))
+
+    async def _send(self, value: bool):
+        setting = dict(self.device["params"].get("alarmSetting", {}))
+        setting[self.field] = value
+        await self.ewelink.send(self.device, {"alarmSetting": setting})
+
+    async def async_turn_on(self, *args, **kwargs):
+        await self._send(True)
+
+    async def async_turn_off(self, *args, **kwargs):
+        await self._send(False)
+
+
+class XAlarmLight(XAlarmSettingSwitch):
+    field = "light"
+    uid = "alarm_light"
+    _attr_icon = "mdi:alarm-light"
+
+
+class XAlarmVoice(XAlarmSettingSwitch):
+    field = "voice"
+    uid = "alarm_sound"
+    _attr_icon = "mdi:volume-high"

--- a/custom_components/sonoff/switch.py
+++ b/custom_components/sonoff/switch.py
@@ -189,16 +189,16 @@ class XAlarmSettingSwitch(XEntity, SwitchEntity):
     def set_state(self, params: dict):
         self._attr_is_on = bool(params.get("alarmSetting", {}).get(self.field))
 
-    async def _send(self, value: bool):
+    async def internal_send(self, value: bool):
         setting = dict(self.device["params"].get("alarmSetting", {}))
         setting[self.field] = value
         await self.ewelink.send(self.device, {"alarmSetting": setting})
 
     async def async_turn_on(self, *args, **kwargs):
-        await self._send(True)
+        await self.internal_send(True)
 
     async def async_turn_off(self, *args, **kwargs):
-        await self._send(False)
+        await self.internal_send(False)
 
 
 class XAlarmLight(XAlarmSettingSwitch):


### PR DESCRIPTION
## Description

Adds support for the Sonoff **SNZB-09P** Zigbee indoor siren, which isn't
currently recognized by this integration.

New entities:

- **button** — trigger the siren (sends `alarmSetting.test = true`). Tested
  and confirmed working on a real device — the siren sounds and
  `alarmType` goes from `none` → `manual` → back to `none` once the
  configured Alarm Duration elapses.
- **switch** — Alarm Sound enable, Alarm Light enable
- **number** — Alarm Duration (seconds), Alarm Volume
- **sensor** — Alarm Sound Type (read-only), Alarm Status
- **binary_sensor** — External Power connected

### How the values were determined

I don't have official docs for this model, so the `uiid` (7056) and the
`params` layout were taken from a real device's Home Assistant diagnostics
dump (device model `SNZB-09P`, connected through a ZBBridge-P). The device
reports its config as a single nested dict:

```json
"alarmSetting": {
  "duration": 10,
  "test": false,
  "alertSound": "alarm0",
  "voice": true,
  "volume": 0,
  "light": true
}
```

### Known gaps / things to double check

- `alertSound` is exposed read-only — I only ever saw `"alarm0"` on my
  device, so I don't know the full list of valid values for a select.
- `volume` range (0–3) is a guess based on the app showing "LOW" as the
  lowest option — could be wider.
- Only tested against a single physical unit connected via a ZBBridge-P
  (cloud control). Not tested with local/LAN-only mode.

Happy to adjust based on maintainer/community feedback, especially if
someone can confirm the `alertSound`/`volume` value ranges from the
eWeLink app or another unit.``