### PR TITLE
Add per-button event entities for SwitchMan M5

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,19 @@ sonoff:
   sensors: [staMac, bssid, host]
 ```
 
+### SwitchMan M5 button events
+
+SwitchMan M5 devices expose a separate `event` entity for each physical button.
+Actions accepted by the existing action sensor are routed to the matching
+button entity, so actions on different buttons do not suppress each other. The
+existing action sensor remains available for backward compatibility.
+Full LAN state snapshots are excluded because they can retain the previous
+button action after an unrelated relay update.
+
+Button actions use Home Assistant event types: `press_end`, `long_press_end`,
+and `multi_press_end`. Multi-press events include the `multi_press_count`
+attribute.
+
 ### Force update
 
 You can request actual device state and all its sensors manually at any time using `homeassistant.update_entity` service. Use it with any device entity except sensors. Use it with only one entity from each device.

--- a/custom_components/sonoff/__init__.py
+++ b/custom_components/sonoff/__init__.py
@@ -57,8 +57,13 @@ PLATFORMS = [
     "remote",
     "switch",
     "number",
-    "select"
+    "select",
 ]
+
+# Event entities were added in Home Assistant 2023.8. Keep the legacy action
+# sensors available on older supported Home Assistant releases.
+if (MAJOR_VERSION, MINOR_VERSION) >= (2023, 8):
+    PLATFORMS.append("event")
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/custom_components/sonoff/core/devices.py
+++ b/custom_components/sonoff/core/devices.py
@@ -16,6 +16,7 @@ from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import MAJOR_VERSION, MINOR_VERSION
 
 from .ewelink import XDevice
 from ..alarm_control_panel import XPanelAlarm
@@ -91,6 +92,9 @@ from ..switch import (
     XZigbeeSwitches,
 )
 
+if (MAJOR_VERSION, MINOR_VERSION) >= (2023, 8):
+    from ..event import XButtonEvent
+
 # supported custom device_class
 DEVICE_CLASS = {
     "binary_sensor": (XEntity, BinarySensorEntity),
@@ -123,6 +127,16 @@ def spec(cls, base: str = None, enabled: bool = None, **kwargs) -> type:
         attrs = unwrap_cached_properties({**attrs, **kwargs})
         return type(cls.__name__, DEVICE_CLASS[base], attrs)
     return type(cls.__name__, (cls,), kwargs)
+
+
+def button_events(count: int) -> list[type]:
+    """Return one event entity class per physical button when supported."""
+    if (MAJOR_VERSION, MINOR_VERSION) < (2023, 8):
+        return []
+    return [
+        spec(XButtonEvent, channel=channel, uid=f"button_{channel + 1}")
+        for channel in range(count)
+    ]
 
 
 Switch1 = spec(XSwitches, channel=0, uid="1")
@@ -421,11 +435,32 @@ DEVICES = {
     # DW2-Wi-Fi-L, https://github.com/AlexxIT/SonoffLAN/issues/808
     154: [XWiFiDoor, Battery, RSSI],
     # Sonoff SwitchMan M5-1C, https://github.com/AlexxIT/SonoffLAN/issues/1432
-    160: [Switch1, LED, RSSI, spec(XButtonLocalKey, uid="action")],
+    160: [
+        Switch1,
+        LED,
+        RSSI,
+        spec(XButtonLocalKey, uid="action"),
+        *button_events(1),
+    ],
     # Sonoff SwitchMan M5-2C, https://github.com/AlexxIT/SonoffLAN/issues/1432
-    161: [Switch1, Switch2, LED, RSSI, spec(XButtonLocalKey, uid="action")],
+    161: [
+        Switch1,
+        Switch2,
+        LED,
+        RSSI,
+        spec(XButtonLocalKey, uid="action"),
+        *button_events(2),
+    ],
     # Sonoff SwitchMan M5-3C, https://github.com/AlexxIT/SonoffLAN/issues/659
-    162: [Switch1, Switch2, Switch3, LED, RSSI, spec(XButtonLocalKey, uid="action")],
+    162: [
+        Switch1,
+        Switch2,
+        Switch3,
+        LED,
+        RSSI,
+        spec(XButtonLocalKey, uid="action"),
+        *button_events(3),
+    ],
     # DualR3 Lite, without power consumption
     165: [
         Switch1,

--- a/custom_components/sonoff/core/ewelink/__init__.py
+++ b/custom_components/sonoff/core/ewelink/__init__.py
@@ -11,6 +11,7 @@ from .local import XRegistryLocal
 _LOGGER = logging.getLogger(__name__)
 
 SIGNAL_ADD_ENTITIES = "add_entities"
+SIGNAL_BUTTON_EVENT = "button_event"
 LOCAL_TTL = 60
 
 

--- a/custom_components/sonoff/event.py
+++ b/custom_components/sonoff/event.py
@@ -1,0 +1,76 @@
+import time
+from typing import ClassVar
+
+from homeassistant.components.event import EventEntity
+from homeassistant.const import MAJOR_VERSION, MINOR_VERSION
+
+from .core.const import DOMAIN
+from .core.entity import XEntity
+from .core.ewelink import SIGNAL_ADD_ENTITIES, SIGNAL_BUTTON_EVENT, XRegistry
+
+if (MAJOR_VERSION, MINOR_VERSION) >= (2026, 8):
+    from homeassistant.components.event import EventDeviceClass
+
+PARALLEL_UPDATES = 0
+
+BUTTON_EVENT_TYPES = ["press_end", "long_press_end", "multi_press_end"]
+BUTTON_EVENTS = {
+    "single": ("press_end", None),
+    "double": ("multi_press_end", {"multi_press_count": 2}),
+    "hold": ("long_press_end", None),
+    "triple": ("multi_press_end", {"multi_press_count": 3}),
+}
+
+_DUPLICATE_WINDOW = 0.5
+
+
+async def async_setup_entry(hass, config_entry, add_entities):
+    ewelink: XRegistry = hass.data[DOMAIN][config_entry.entry_id]
+    ewelink.dispatcher_connect(
+        SIGNAL_ADD_ENTITIES,
+        lambda x: add_entities([e for e in x if isinstance(e, EventEntity)]),
+    )
+
+
+class XButtonEvent(XEntity, EventEntity):
+    """One event stream for one physical button."""
+
+    event = True
+    channel: ClassVar[int]
+
+    _attr_event_types = BUTTON_EVENT_TYPES
+
+    if (MAJOR_VERSION, MINOR_VERSION) >= (2026, 8):
+        _attr_device_class = EventDeviceClass.BUTTON
+
+    def __init__(self, ewelink: XRegistry, device: dict):
+        self.last_event_action = None
+        self.last_event_at = 0.0
+        super().__init__(ewelink, device)
+        ewelink.dispatcher_connect(SIGNAL_BUTTON_EVENT, self.internal_button_event)
+
+    def internal_button_event(
+        self,
+        deviceid: str,
+        button: int | None,
+        action: str,
+    ):
+        if deviceid != self.device["deviceid"] or button != self.channel:
+            return
+
+        event = BUTTON_EVENTS.get(action)
+        if event is None:
+            return
+
+        now = time.monotonic()
+        if (
+            action == self.last_event_action
+            and now - self.last_event_at < _DUPLICATE_WINDOW
+        ):
+            return
+
+        self.last_event_action = action
+        self.last_event_at = now
+        self._trigger_event(*event)
+        if self.hass:
+            self._async_write_ha_state()

--- a/custom_components/sonoff/sensor.py
+++ b/custom_components/sonoff/sensor.py
@@ -23,7 +23,7 @@ from homeassistant.util import dt
 
 from .core.const import DOMAIN
 from .core.entity import XEntity
-from .core.ewelink import SIGNAL_ADD_ENTITIES, XRegistry
+from .core.ewelink import SIGNAL_ADD_ENTITIES, SIGNAL_BUTTON_EVENT, XRegistry
 
 PARALLEL_UPDATES = 0  # fix entity_platform parallel_updates Semaphore
 
@@ -395,9 +395,13 @@ class XEventSesor(XEntity, SensorEntity):
 
 
 class XButtonBase(XEventSesor):
-    def set_state(self, params: dict):
+    @staticmethod
+    def decode_action(params: dict) -> tuple[int | None, str]:
         button = params.get("outlet")
-        key = BUTTON_STATES[params["key"]]
+        return button, BUTTON_STATES[params["key"]]
+
+    def set_state(self, params: dict):
+        button, key = self.decode_action(params)
         self._attr_native_value = (
             f"button_{button + 1}_{key}" if button is not None else key
         )
@@ -437,13 +441,9 @@ class XButtonLocalKey(XButtonBase):
             if self.last_seq is None:
                 self.last_seq = seq
 
-        # skip multiple clicks (from cloud and local)
-        if self._attr_native_value:
-            return
-
         # cloud click: {'localKeyPass': {'outlet': 0, 'key': 0}}
         if len(params) == 1:
-            pass
+            standalone_action = True
         # local click: {'triggerType': 11, 'localKeyPass': {'outlet': 0, 'key': 0}}
         # local trash: {'triggerType': 0, 'localKeyPass': {'outlet': 0, 'key': 0}}
         # local trash: {'triggerType': 2, 'localKeyPass': {'outlet': 0, 'key': 0}}
@@ -453,12 +453,26 @@ class XButtonLocalKey(XButtonBase):
             if seq == self.last_seq:
                 return
             self.last_seq = seq
+            # Full LAN state snapshots retain the previous localKeyPass value.
+            standalone_action = params.keys() == {"triggerType", "localKeyPass"}
         else:
             return
 
         # MINI-2GS https://github.com/AlexxIT/SonoffLAN/issues/1694
         # MINI-ZB2GS-L https://github.com/AlexxIT/SonoffLAN/issues/1701
-        XButtonBase.set_state(self, params["localKeyPass"])
+        payload = params["localKeyPass"]
+        if standalone_action:
+            button, action = self.decode_action(payload)
+            self.ewelink.dispatcher_send(
+                SIGNAL_BUTTON_EVENT,
+                self.device["deviceid"],
+                button,
+                action,
+            )
+
+        # Preserve the legacy common action sensor and its transport deduplication.
+        if not self._attr_native_value:
+            XButtonBase.set_state(self, payload)
 
 
 class XT5Action(XEventSesor):

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -36,6 +36,7 @@ from custom_components.sonoff.core.ewelink import (
     SIGNAL_UPDATE,
 )
 from custom_components.sonoff.cover import XCover, XCoverDualR3, XCoverOP, XZigbeeCover
+from custom_components.sonoff.event import XButtonEvent
 from custom_components.sonoff.fan import XFan, XFan17, XToggleFan
 from custom_components.sonoff.light import (
     UIID22_MODES,
@@ -2420,6 +2421,14 @@ def test_m5_matter():
     )
 
     button: XButtonLocalKey = next(e for e in entities if e.uid == "action")
+    button_events: list[XButtonEvent] = [
+        e for e in entities if isinstance(e, XButtonEvent)
+    ]
+    assert [event.uid for event in button_events] == [
+        "button_1",
+        "button_2",
+        "button_3",
+    ]
     assert button.state == ""
 
     # this is local event without trigger
@@ -2431,6 +2440,7 @@ def test_m5_matter():
         },
     )
     assert button.state == ""
+    assert button_events[0].state is None
 
     # this is cloud event with trigger
     button.ewelink.cloud.dispatcher_send(
@@ -2438,6 +2448,17 @@ def test_m5_matter():
         {"deviceid": DEVICEID, "params": {"localKeyPass": {"key": 0, "outlet": 0}}},
     )
     assert button.state == "button_1_single"
+    assert button_events[0].state_attributes == {"event_type": "press_end"}
+
+    # A second physical button has an independent stream even while the legacy
+    # action sensor is still holding the first action for deduplication.
+    button.ewelink.cloud.dispatcher_send(
+        SIGNAL_UPDATE,
+        {"deviceid": DEVICEID, "params": {"localKeyPass": {"key": 0, "outlet": 1}}},
+    )
+    assert button.state == "button_1_single"
+    assert button_events[1].state_attributes == {"event_type": "press_end"}
+    button_2_state = button_events[1].state
 
     # this is first local event with trigger (device discovery)
     setattr(button, "_attr_native_value", "")  # reset state
@@ -2450,6 +2471,7 @@ def test_m5_matter():
         },
     )
     assert button.state == ""
+    assert button_events[1].state == button_2_state
 
     # this is second local event with trigger
     setattr(button, "_attr_native_value", "")  # reset state
@@ -2474,6 +2496,103 @@ def test_m5_matter():
         },
     )
     assert button.state == ""
+    assert button_events[2].state is None
+
+
+def test_m5_button_event_types():
+    for key, event_type, attributes in (
+        (0, "press_end", {}),
+        (1, "multi_press_end", {"multi_press_count": 2}),
+        (2, "long_press_end", {}),
+        (3, "multi_press_end", {"multi_press_count": 3}),
+    ):
+        registry, entities = init(
+            {
+                "extra": {"uiid": 160},
+                "params": {"localKeyPass": {"key": 0, "outlet": 0}},
+            }
+        )
+        button: XButtonEvent = next(e for e in entities if isinstance(e, XButtonEvent))
+        registry.cloud.dispatcher_send(
+            SIGNAL_UPDATE,
+            {
+                "deviceid": DEVICEID,
+                "params": {"localKeyPass": {"key": key, "outlet": 0}},
+            },
+        )
+        assert button.state_attributes == {"event_type": event_type, **attributes}
+
+
+def test_m5_button_event_deduplicates_cloud_and_local():
+    registry, entities = init(
+        {
+            "extra": {"uiid": 160},
+            "params": {"localKeyPass": {"key": 0, "outlet": 0}},
+        }
+    )
+    button: XButtonEvent = next(e for e in entities if isinstance(e, XButtonEvent))
+
+    # First local packet is device discovery and establishes the sequence.
+    registry.local.dispatcher_send(
+        SIGNAL_UPDATE,
+        {
+            "deviceid": DEVICEID,
+            "params": {"triggerType": 11, "localKeyPass": {"key": 0, "outlet": 0}},
+            "seq": 1,
+        },
+    )
+    assert button.state is None
+
+    registry.cloud.dispatcher_send(
+        SIGNAL_UPDATE,
+        {"deviceid": DEVICEID, "params": {"localKeyPass": {"key": 0, "outlet": 0}}},
+    )
+    state = button.state
+    assert state is not None
+    event_at = button.last_event_at
+
+    registry.cloud.dispatcher_send(
+        SIGNAL_UPDATE,
+        {"deviceid": DEVICEID, "params": {"localKeyPass": {"key": 0, "outlet": 0}}},
+    )
+    assert button.last_event_at == event_at
+
+    registry.local.dispatcher_send(
+        SIGNAL_UPDATE,
+        {
+            "deviceid": DEVICEID,
+            "params": {"triggerType": 11, "localKeyPass": {"key": 0, "outlet": 0}},
+            "seq": 2,
+        },
+    )
+    assert button.state == state
+    assert button.last_event_at == event_at
+
+
+def test_m5_button_event_ignores_local_state_snapshot():
+    registry, entities = init(
+        {
+            "extra": {"uiid": 160},
+            "params": {"localKeyPass": {"key": 0, "outlet": 0}},
+        }
+    )
+    button: XButtonEvent = next(e for e in entities if isinstance(e, XButtonEvent))
+
+    for seq in (1, 2):
+        registry.local.dispatcher_send(
+            SIGNAL_UPDATE,
+            {
+                "deviceid": DEVICEID,
+                "params": {
+                    "switches": [{"outlet": 0, "switch": "off"}],
+                    "triggerType": 11,
+                    "localKeyPass": {"key": 0, "outlet": 0},
+                },
+                "seq": seq,
+            },
+        )
+
+    assert button.state is None
 
 
 def test_powct():


### PR DESCRIPTION
## Summary

- add one Home Assistant `event` entity per physical button on SwitchMan M5 1C, 2C, and 3C devices
- keep the existing shared action sensor for backward compatibility
- map single, double, hold, and triple actions to button event types
- deduplicate repeated actions per button without suppressing a different button on the same device
- ignore full LAN state snapshots when routing button events

## Why

The existing M5 action sensor holds its state for 0.5 seconds to deduplicate transport updates. Because all buttons share that sensor, an action from one button can suppress an action from another button during that window.

M5 firmware 1.2.0 also retains the previous `localKeyPass` in full LAN state snapshots. Treating every such snapshot as a new button event causes phantom actions after relay updates. The new per-button streams therefore accept only standalone action payloads (`localKeyPass` by itself, or a minimal LAN payload containing only `triggerType` and `localKeyPass`). The legacy action sensor keeps its existing behavior.

The event platform is enabled only on Home Assistant 2023.8 and newer, matching the version where `EventEntity` was introduced.

## Validation

- `97 passed` against Home Assistant 2026.8.1
- production files pass Ruff critical-error checks (`E9,F63,F7,F82`)
- `ha core check` passes on Home Assistant Green running 2026.8.1
- live M5-2C test: simultaneous button actions produced separate events 7 ms apart; Unified Device copies followed within 1-2 ms
- delayed LAN state snapshots carrying the previous `localKeyPass` did not retrigger either event during the following 4 seconds
