### PR TITLE
Fix phantom button action from SwitchMan M5 full state reports

### DIFF
--- a/custom_components/sonoff/sensor.py
+++ b/custom_components/sonoff/sensor.py
@@ -449,6 +449,11 @@ class XButtonLocalKey(XButtonBase):
         # local trash: {'triggerType': 2, 'localKeyPass': {'outlet': 0, 'key': 0}}
         # based on https://github.com/AlexxIT/SonoffLAN/issues/1789
         elif params.get("triggerType") == 11:
+            # full state reports (e.g. after a relay command) also carry
+            # triggerType 11 and the stale localKeyPass of the last press
+            # https://github.com/AlexxIT/SonoffLAN/issues/1835
+            if "switches" in params:
+                return
             # Fix duplicates from mDNS https://github.com/AlexxIT/SonoffLAN/issues/1769
             if seq == self.last_seq:
                 return

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -2475,6 +2475,48 @@ def test_m5_matter():
     )
     assert button.state == ""
 
+    # this is a full state report after a relay command - it carries
+    # triggerType 11 and the stale localKeyPass of the LAST press, and
+    # must not be mistaken for a new press
+    # https://github.com/AlexxIT/SonoffLAN/issues/1835
+    setattr(button, "_attr_native_value", "")  # reset state
+    button.ewelink.local.dispatcher_send(
+        SIGNAL_UPDATE,
+        {
+            "deviceid": DEVICEID,
+            "params": {
+                "sledOnline": "on",
+                "configure": [
+                    {"outlet": 0, "startup": "stay", "enableDelay": 0, "width": 29000},
+                    {"outlet": 1, "startup": "stay", "enableDelay": 0, "width": 22000},
+                    {"outlet": 2, "startup": "stay", "enableDelay": 0, "width": 2000},
+                ],
+                "switches": [
+                    {"outlet": 0, "switch": "on"},
+                    {"outlet": 1, "switch": "off"},
+                    {"outlet": 2, "switch": "on"},
+                ],
+                "triggerType": 11,
+                "lock": 0,
+                "localKeyPass": {"key": 0, "outlet": 2},
+            },
+            "seq": 3,
+        },
+    )
+    assert button.state == ""
+
+    # and a real press right after a state report still works
+    setattr(button, "_attr_native_value", "")  # reset state
+    button.ewelink.local.dispatcher_send(
+        SIGNAL_UPDATE,
+        {
+            "deviceid": DEVICEID,
+            "params": {"triggerType": 11, "localKeyPass": {"key": 0, "outlet": 2}},
+            "seq": 4,
+        },
+    )
+    assert button.state == "button_3_single"
+
 
 def test_powct():
     entities = get_entitites({"extra": {"uiid": 190}, "params": {"supplyPower": 0}})


### PR DESCRIPTION
## The bug

On SwitchMan M5 (uiid 160/161/162; observed on M5-3C-86W, fw 1.2.0), the `_action` sensor emits a spurious `button_N_single` ~250 ms after **any HA-commanded relay change** on the device. The replayed value is always the **last real button press**. Any automation bound to the action sensor re-fires on every commanded relay change — e.g. an automation turning on a bathroom fan channel would toggle the lights bound to the detached channel's button.

This is the surviving case of #1789 (fixed for some paths in v3.12.1) and matches the open reports in #1835.

## Root cause (packet capture)

After a commanded relay change, the M5 broadcasts a **full state report** over LAN. Captured with debug logging on v3.12.2:

```
1002a75c16 <= Local3 | 192.168.4.32:8081 | {'sledOnline': 'on', 'offBrightness': 10,
 'relaySeparations': [...], 'configure': [...], 'pulses': [...],
 'switches': [{'outlet': 0, 'switch': 'on'}, {'outlet': 1, 'switch': 'on'}, {'outlet': 2, 'switch': 'on'}],
 'triggerType': 11, 'lock': 0,
 'localKeyPass': {'outlet': 2, 'key': 0}, ...} | 99
```

The report carries **`triggerType: 11`** and the **stale `localKeyPass`** of the last real press (`outlet: 2` = button 3, pressed minutes earlier). `XButtonLocalKey` discriminates local clicks only by `triggerType == 11` + a fresh seq — both of which every post-command state report satisfies. So the stale press replays as a fresh event.

## The fix

A real click arrives as a standalone `{'triggerType': 11, 'localKeyPass': {...}}` payload and never carries relay state. Ignore any message that contains `switches`:

```python
elif params.get("triggerType") == 11:
    if "switches" in params:
        return
```

The seq counter is deliberately not consumed by rejected reports, so a real click immediately after a report still registers.

## Verification

- New test in `test_m5_matter` replays the captured state report verbatim (fails on master with `button_3_single`, passes with the fix), plus a follow-up real-press payload proving clicks still work.
- Full suite: 94 passed.
- Live on the affected M5-3C-86W: commanded relay pulses no longer emit any action (previously 100% reproduction, ~250 ms echo); a physical press of the detached button still emits `button_3_single` normally (~190 ms).

Fixes the mechanism reported in #1835; follow-up to #1789. Note the cloud path (bare `localKeyPass` diff, accepted when `len(params) == 1`) is left untouched — on this firmware the cloud only diffs `switches` after a command, so I could not reproduce a cloud-side phantom to test against.
