### PR TITLE
Add support for CK-BL602-TC-01 gate motor controller (uiid 216)

### DIFF
--- a/custom_components/sonoff/core/devices.py
+++ b/custom_components/sonoff/core/devices.py
@@ -32,7 +32,7 @@ from ..climate import XClimateNS, XClimateTH, XThermostat, XThermostatTRVZB
 from ..core.entity import XEntity
 from ..cover import (
     XCover,
-    XCoverBL602Door,
+    XCover216,
     XCoverDualR3,
     XCoverOP,
     XCoverT5,
@@ -542,7 +542,7 @@ DEVICES = {
     + TX_ULTIMATE,
     # CK-BL602-TC-01(216), CoolKit gate motor controller
     # (VEVOR MD370/MD750 etc.), https://github.com/AlexxIT/SonoffLAN/issues/1819
-    216: [XCoverBL602Door, RSSI],
+    216: [XCover216, RSSI],
     # CK-BL602-PCSW-01(225), https://github.com/AlexxIT/SonoffLAN/issues/1616
     225: [
         spec(XBoolSwitch, param="switch"),

--- a/custom_components/sonoff/core/devices.py
+++ b/custom_components/sonoff/core/devices.py
@@ -30,7 +30,15 @@ from ..binary_sensor import (
 from ..button import XButton, XT5Effect
 from ..climate import XClimateNS, XClimateTH, XThermostat, XThermostatTRVZB
 from ..core.entity import XEntity
-from ..cover import XCover, XCoverDualR3, XCoverOP, XCoverT5, XZBCover, XZigbeeCover
+from ..cover import (
+    XCover,
+    XCoverBL602Door,
+    XCoverDualR3,
+    XCoverOP,
+    XCoverT5,
+    XZBCover,
+    XZigbeeCover,
+)
 from ..fan import XDiffuserFan, XFan, XFan17, XFanDualR3, XToggleFan
 from ..light import (
     XDiffuserLight,
@@ -532,6 +540,9 @@ DEVICES = {
         Startup4,
     ]
     + TX_ULTIMATE,
+    # CK-BL602-TC-01(216), CoolKit gate motor controller
+    # (VEVOR MD370/MD750 etc.), https://github.com/AlexxIT/SonoffLAN/issues/1819
+    216: [XCoverBL602Door, RSSI],
     # CK-BL602-PCSW-01(225), https://github.com/AlexxIT/SonoffLAN/issues/1616
     225: [
         spec(XBoolSwitch, param="switch"),

--- a/custom_components/sonoff/cover.py
+++ b/custom_components/sonoff/cover.py
@@ -1,4 +1,8 @@
-from homeassistant.components.cover import CoverDeviceClass, CoverEntity
+from homeassistant.components.cover import (
+    CoverDeviceClass,
+    CoverEntity,
+    CoverEntityFeature,
+)
 
 from .core.const import DOMAIN
 from .core.entity import XEntity
@@ -245,3 +249,59 @@ class XCoverT5(XCover):
 
     async def async_set_cover_position(self, position: int, **kwargs):
         await self.ewelink.send(self.device, {"percentageControl": 100 - position})
+
+
+# noinspection PyAbstractClass
+class XCoverBL602Door(XCover):
+    # CoolKit CK-BL602-TC-01 (uiid 216) — VEVOR MD370/MD750 sliding gate motor.
+    # Only a bottom endstop is reported: doorState 0=fully closed, 1=not-fully-closed.
+    # There is no reliable "fully open" or motion signal from the device, so we only
+    # expose closed/open and closing (whose end we know from doorState=0). We do not
+    # expose "opening" — it would just be a guess.
+    params = {"switch", "doorState"}
+    event = True  # skip initial set_state; seed from device["params"] in __init__
+    _attr_device_class = CoverDeviceClass.GATE
+    _attr_supported_features = (
+        CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.STOP
+    )
+    _attr_is_closed = None
+    # Only bottom endstop is known — "open" really means "not fully closed".
+    # Keep all controls active so the user can re-issue open/close/stop from any state.
+    _attr_assumed_state = True
+
+    def __init__(self, ewelink: XRegistry, device: dict):
+        super().__init__(ewelink, device)
+        ds = device["params"].get("doorState")
+        if ds is not None:
+            self._attr_is_closed = ds == 0
+
+    def set_state(self, params: dict):
+        # Only lone doorState pushes reflect real endstop transitions. Command echoes
+        # and full state dumps also contain doorState but with pre-command values.
+        if "doorState" not in params or "switch" in params:
+            return
+        state = params["doorState"]
+        self._attr_is_closed = state == 0
+        if state == 0:
+            # Bottom endstop reached → gate is fully closed, closing done.
+            self._attr_is_closing = False
+
+    async def async_open_cover(self, **kwargs):
+        self._attr_is_closing = False
+        self._attr_is_closed = False
+        self._async_write_ha_state()
+        await self.ewelink.send(self.device, {"switch": "on"}, query_cloud=False)
+
+    async def async_close_cover(self, **kwargs):
+        self._attr_is_closing = True
+        self._async_write_ha_state()
+        await self.ewelink.send(self.device, {"switch": "off"}, query_cloud=False)
+
+    async def async_stop_cover(self, **kwargs):
+        self._attr_is_closing = False
+        self._async_write_ha_state()
+        await self.ewelink.send(self.device, {"switch": "pause"}, query_cloud=False)
+
+    async def async_set_cover_position(self, position: int, **kwargs):
+        # Device has no position control — no-op.
+        return

--- a/custom_components/sonoff/cover.py
+++ b/custom_components/sonoff/cover.py
@@ -252,56 +252,21 @@ class XCoverT5(XCover):
 
 
 # noinspection PyAbstractClass
-class XCoverBL602Door(XCover):
-    # CoolKit CK-BL602-TC-01 (uiid 216) — VEVOR MD370/MD750 sliding gate motor.
-    # Only a bottom endstop is reported: doorState 0=fully closed, 1=not-fully-closed.
-    # There is no reliable "fully open" or motion signal from the device, so we only
-    # expose closed/open and closing (whose end we know from doorState=0). We do not
-    # expose "opening" — it would just be a guess.
+class XCover216(XCover):
     params = {"switch", "doorState"}
-    event = True  # skip initial set_state; seed from device["params"] in __init__
     _attr_device_class = CoverDeviceClass.GATE
-    _attr_supported_features = (
-        CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.STOP
-    )
     _attr_is_closed = None
-    # Only bottom endstop is known — "open" really means "not fully closed".
-    # Keep all controls active so the user can re-issue open/close/stop from any state.
-    _attr_assumed_state = True
-
-    def __init__(self, ewelink: XRegistry, device: dict):
-        super().__init__(ewelink, device)
-        ds = device["params"].get("doorState")
-        if ds is not None:
-            self._attr_is_closed = ds == 0
 
     def set_state(self, params: dict):
-        # Only lone doorState pushes reflect real endstop transitions. Command echoes
-        # and full state dumps also contain doorState but with pre-command values.
-        if "doorState" not in params or "switch" in params:
-            return
-        state = params["doorState"]
-        self._attr_is_closed = state == 0
-        if state == 0:
-            # Bottom endstop reached → gate is fully closed, closing done.
-            self._attr_is_closing = False
+        # => command to cover from mobile app (ignore initial state)
+        if len(params) == 1 and "switch" in params:
+            # device receive command - on=open/off=close/pause=stop
+            self._attr_is_opening = params["switch"] == "on"
+            self._attr_is_closing = params["switch"] == "off"
 
-    async def async_open_cover(self, **kwargs):
-        self._attr_is_closing = False
-        self._attr_is_closed = False
-        self._async_write_ha_state()
-        await self.ewelink.send(self.device, {"switch": "on"}, query_cloud=False)
-
-    async def async_close_cover(self, **kwargs):
-        self._attr_is_closing = True
-        self._async_write_ha_state()
-        await self.ewelink.send(self.device, {"switch": "off"}, query_cloud=False)
-
-    async def async_stop_cover(self, **kwargs):
-        self._attr_is_closing = False
-        self._async_write_ha_state()
-        await self.ewelink.send(self.device, {"switch": "pause"}, query_cloud=False)
+        if "doorState" in params:
+            self._attr_is_closing = self._attr_is_opening = False
+            self._attr_is_closed = params["doorState"] == 0
 
     async def async_set_cover_position(self, position: int, **kwargs):
-        # Device has no position control — no-op.
-        return
+        return  # Device has no position control — no-op.


### PR DESCRIPTION
  Fixes #1819.                                                                                                                                      
                                                                                                                                                    
  Adds support for CoolKit `CK-BL602-TC-01` (uiid 216), the eWeLink-based Wi-Fi module found in **VEVOR MD370 / MD750** and other rebranded         
  sliding-gate motors. Reported at #1819 (with device dump).                                                                                        
                                                                                                                                                    
  Exposed as a `cover` with `device_class: gate`.                                                                                                   
                                                                                                                                                    
  ### Commands                                                                                                                                      
  | HA action  | Sent to device        |                                                                                                            
  |------------|-----------------------|                                                                                                            
  | open       | `{"switch": "on"}`    |                                                                                                            
  | close      | `{"switch": "off"}`   |                                                                                                            
  | stop       | `{"switch": "pause"}` |                                                                                                            
                                                                                                                                                    
  The `switch` value only echoes the last command intent — it is not the motor state, so it is ignored for state derivation.                        
                                                                                                                                                    
  ### Feedback                                                                                                                                      
  The device only has a **bottom endstop**. It pushes lone `doorState` updates:                                                                     
                                                                                                                                                    
  | doorState | Meaning                                                     |                                                                       
  |-----------|-------------------------------------------------------------|                                                                       
  | `0`       | Bottom endstop reached — fully closed                       |                                                                       
  | `1`       | Bottom endstop left — anywhere between 1 cm open and fully open |                                                                   
                                                                                                                                                    
  Verified with debug log on hardware (motor: VEVOR sliding-gate, FW 1.1.0):                                                                        
                                                                                                                                                    
  send switch:on  -> doorState:1 arrives ~800 ms later (endstop left)                                                                               
  send switch:off -> doorState:0 arrives ~18 s later (endstop reached)
  send switch:pause during travel -> motor stops, no doorState push
  ### Design decisions                                                     
  - **No `opening` state exposed** — with only a bottom endstop, any "opening" state would be a guess. There is no reliable "fully open" signal from
  the device.                                                              
  - **`closing` IS exposed** because its end is deterministic (`doorState:0`).
  - **`assumed_state = True`** so the open/close/stop controls stay callable regardless of `is_closed`. Without it, HA disables the open button once
  the gate has left the closed endstop, preventing continued opening after a mid-travel stop. The eWeLink app allows this and users expect the
  same.                                                                    
  - **No `set_cover_position`** — the device has no position control.      

  ### Tested                                                               
  Live-tested on a VEVOR MD-series sliding-gate motor over multiple open/close/stop cycles including mid-travel resumption.