### PR TITLE
Fix UIID 127 thermostats that omit workState and workMode

### DIFF
--- a/custom_components/sonoff/climate.py
+++ b/custom_components/sonoff/climate.py
@@ -250,6 +250,7 @@ class XThermostat(XEntity, ClimateEntity):
     _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.AUTO]
     _attr_max_temp = 45
     _attr_min_temp = 5
+    _attr_preset_mode = None
     _attr_preset_modes = ["manual", "programmed", "economical"]
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_target_temperature_step = 0.5
@@ -269,7 +270,8 @@ class XThermostat(XEntity, ClimateEntity):
 
         if cache["switch"] == "on":
             # workState: 1=heating, 2=auto
-            self._attr_hvac_mode = self.hvac_modes[cache["workState"]]
+            # Some UIID 127 thermostats (ZK-H/ZKWY) do not report workState.
+            self._attr_hvac_mode = self.hvac_modes[cache.get("workState", 1)]
         else:
             self._attr_hvac_mode = HVACMode.OFF
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,6 +1,6 @@
 from homeassistant.components.climate import HVACMode
 
-from custom_components.sonoff.climate import XClimateTH, XThermostatTRVZB
+from custom_components.sonoff.climate import XClimateTH, XThermostat, XThermostatTRVZB
 from . import init
 
 
@@ -218,3 +218,77 @@ def test_trvzb_unknown_workmode():
     # Setting a known workMode after unknown ones should work
     climate.set_state({"workMode": "0"})
     assert climate.hvac_mode == HVACMode.HEAT
+
+
+def test_thermostat_without_workstate():
+    # Reduced UIID 127 ZKWY/CK-BL602-TC-01 payload, without account/device IDs.
+    reg, entities = init(
+        {
+            "extra": {"uiid": 127},
+            "params": {"switch": "on", "temperature": 35.8, "targetTemp": 38},
+        }
+    )
+    climate = next(e for e in entities if isinstance(e, XThermostat))
+    assert climate.hvac_mode == HVACMode.HEAT
+    assert climate.current_temperature == 35.8
+    assert climate.target_temperature == 38
+    assert climate.available
+
+    # Partial updates retain the cached power state and target temperature.
+    climate.internal_update({"temperature": 36.2})
+    assert climate.hvac_mode == HVACMode.HEAT
+    assert climate.current_temperature == 36.2
+    assert climate.target_temperature == 38
+
+    climate.internal_update({"switch": "off"})
+    assert climate.hvac_mode == HVACMode.OFF
+    climate.internal_update({"switch": "on", "targetTemp": 37.5})
+    assert climate.hvac_mode == HVACMode.HEAT
+    assert climate.target_temperature == 37.5
+
+    # Temperature-only commands must not add an unsupported workState field.
+    _, params = reg.call(climate.async_set_temperature(temperature=37))
+    assert params == {"targetTemp": 37}
+    _, params = reg.call(climate.async_set_hvac_mode(HVACMode.OFF))
+    assert params == {"switch": "off"}
+
+    # A cached temperature must not force an offline device to be available.
+    climate.device["online"] = False
+    climate.internal_update({"temperature": 36.2})
+    assert not climate.available
+    climate.device["online"] = True
+    climate.internal_update()
+    assert climate.available
+
+
+def test_thermostat_with_workstate():
+    reg, entities = init(
+        {
+            "extra": {"uiid": 127},
+            "params": {
+                "switch": "on",
+                "workState": 2,
+                "workMode": 2,
+                "temperature": 20,
+                "targetTemp": 22,
+            },
+        }
+    )
+    climate = next(e for e in entities if isinstance(e, XThermostat))
+    assert climate.hvac_mode == HVACMode.AUTO
+    assert climate.preset_mode == "programmed"
+
+    climate.internal_update({"temperature": 20.5})
+    assert climate.hvac_mode == HVACMode.AUTO
+    climate.internal_update({"workState": 1, "workMode": 1})
+    assert climate.hvac_mode == HVACMode.HEAT
+    assert climate.preset_mode == "manual"
+    climate.internal_update({"switch": "off"})
+    assert climate.hvac_mode == HVACMode.OFF
+
+    _, params = reg.call(climate.async_set_hvac_mode(HVACMode.AUTO))
+    assert params == {"switch": "on", "workState": 2}
+    _, params = reg.call(
+        climate.async_set_temperature(temperature=23, hvac_mode=HVACMode.HEAT)
+    )
+    assert params == {"switch": "on", "workState": 1, "targetTemp": 23}


### PR DESCRIPTION
## Problem

Some UIID 127 thermostats sold as ZK-H/ZKWY (including CK-BL602-TC-01) report `switch`, `temperature`, and `targetTemp`, but omit `workState` and `workMode`. `XThermostat.set_state()` indexes `cache["workState"]`, raising `KeyError` during initialization. After that is fixed, Home Assistant 2025.8.3 also needs an initialized preset value when `workMode` is absent.

Reduced device payload used to reproduce the problem:

```json
{"extra":{"uiid":127},"params":{"switch":"on","temperature":35.8,"targetTemp":38}}
```

## Change

Default a missing `workState` to the existing heat-mode value (1) when the switch is on. Preserve OFF handling and the supplied workState behavior. Initialize the current preset to `None` until the device reports `workMode`.

Add regression tests for initialization, partial temperature updates, power-state transitions, command payloads, and offline/reconnect availability. Existing AUTO/HEAT and preset behavior is covered as well.

Normal connection-based availability, advertised modes, and command protocol remain unchanged. A cached temperature does not force a device online.

## Validation

Python 3.13.15, Home Assistant 2025.8.3: `python -m pytest tests -q` — **96 passed**, with one existing aiohttp deprecation warning. `git diff --check` passes.

The new missing-state regression fails on unmodified upstream code with `KeyError: workState`, and passes with this change.

Based on real device diagnostics and an existing local workaround on two thermostats. This exact upstream patch was tested in the repository suite, not deployed to the live devices; physical command behavior is not newly claimed here.

The fixtures contain only the fields needed to reproduce the issue; no account data, device keys, or tokens are included.